### PR TITLE
Update hostio chainid to u64 instead of Bytes32

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -31,7 +31,7 @@ wrap_hostio!(
     /// determined.
     ///
     /// [`Block Numbers and Time`]: https://developer.arbitrum.io/time
-    number block_number B256
+    number block_number u64
 );
 
 wrap_hostio!(

--- a/src/hostio.rs
+++ b/src/hostio.rs
@@ -64,7 +64,7 @@ extern "C" {
     /// determined.
     ///
     /// [`Block Numbers and Time`]: https://developer.arbitrum.io/time
-    pub(crate) fn block_number(number: *mut u8);
+    pub(crate) fn block_number() -> u64;
 
     /// Gets a bounded estimate of the Unix timestamp at which the Sequencer sequenced the
     /// transaction. See [`Block Numbers and Time`] for more information on how this value is


### PR DESCRIPTION
Required by:
https://github.com/OffchainLabs/stylus/pull/106