### PR TITLE
Define a Derive Macro for Erase on Structs

### DIFF
--- a/stylus-proc/src/storage.rs
+++ b/stylus-proc/src/storage.rs
@@ -37,6 +37,7 @@ pub struct SolidityStruct {
 
 impl Parse for SolidityStruct {
     fn parse(input: ParseStream) -> Result<Self> {
+        // #[attrs?]
         // pub? struct name
         let attrs: Vec<Attribute> = Attribute::parse_outer(input)?;
         let vis: Visibility = input.parse()?;


### PR DESCRIPTION
This PR adds a derive macro for the ability to automatically implement `Erase` on structs. This means that instead of calling `.erase()` for each field in a struct, we can do `struct.erase()` with this derive rule. This can be used in standalone Rust or inside of the `sol_storage!` macro. This also adds the ability to add custom attributes to structs defined inside of `sol_storage!`. If the derive macro is used on a struct that contains maps or other types that aren't Erase, compilation will fail.
```rust

sol_storage! {
    pub struct Contract {
        bool flag;
        address owner;
        address other;
        Struct sub;
        Struct[] structs;
        uint64[] vector;
        uint40[][] nested;
        bytes bytes_full;
        bytes bytes_long;
        string chars;
        Maps maps;
    };

    #[derive(Erase)]
    pub struct Struct {
        uint16 num;
        int32 other;
        bytes32 word;
    };

    pub struct Maps {
        mapping(uint256 => address) basic;
        mapping(address => bool[]) vects;
        mapping(int32 => address)[] array;
        mapping(bytes1 => mapping(bool => uint256)) nested;
        mapping(string => Struct) structs;
    };

    #[derive(Erase)]
    pub struct Foo {
        bool flag;
        address owner;
        Struct[] structs;
        uint64[] vector;
    }
}

// ... in some tests...
fn remove() {
    let mut contract = unsafe { Contract::new(U256::ZERO, 0) };
    let mut structs = contract.structs;
    for idx in 0..structs.len() {
        let mut st = structs.setter(U8::from(idx)).unwrap();
        st.erase();
    }

    let mut foo = unsafe { Foo::new(U256::ZERO, 0) };
    foo.erase();
}
```