### PR TITLE
Rename `ClearStorageType` to `Erasable`

### DIFF
--- a/stylus-sdk/src/storage/bytes.rs
+++ b/stylus-sdk/src/storage/bytes.rs
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
 use super::{
-    ClearStorageType, StorageB8, StorageCache, StorageGuard, StorageGuardMut, StorageType,
+    Erasable, StorageB8, StorageCache, StorageGuard, StorageGuardMut, StorageType,
 };
 use crate::crypto;
 use alloy_primitives::{U256, U8};
@@ -207,7 +207,7 @@ impl StorageBytes {
 
     /// Overwrites the contents of the collection, erasing what was previously stored.
     pub fn set_bytes(&mut self, bytes: impl AsRef<[u8]>) {
-        self.clear();
+        self.erase();
         self.extend(bytes.as_ref());
     }
 
@@ -227,8 +227,8 @@ impl StorageBytes {
     }
 }
 
-impl ClearStorageType for StorageBytes {
-    fn clear(&mut self) {
+impl Erasable for StorageBytes {
+    fn erase(&mut self) {
         let mut len = self.len() as isize;
         if len > 31 {
             while len > 0 {
@@ -305,16 +305,16 @@ impl StorageString {
 
     /// Overwrites the underlying [`String`], erasing what was previously stored.
     pub fn set_str(&mut self, text: impl AsRef<str>) {
-        self.clear();
+        self.erase();
         for c in text.as_ref().chars() {
             self.push(c);
         }
     }
 }
 
-impl ClearStorageType for StorageString {
-    fn clear(&mut self) {
-        self.0.clear()
+impl Erasable for StorageString {
+    fn erase(&mut self) {
+        self.0.erase()
     }
 }
 

--- a/stylus-sdk/src/storage/cache.rs
+++ b/stylus-sdk/src/storage/cache.rs
@@ -327,7 +327,7 @@ pub trait StorageType: Sized {
 /// Note that some collections, like [`StorageMap`], don't implement this trait.
 pub trait ClearStorageType: StorageType {
     /// Erase the value from persistent storage.
-    fn clear(&mut self);
+    fn erase(&mut self);
 }
 
 /// Trait for simple accessors that store no more than their wrapped value.

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -6,7 +6,7 @@ use std::{cell::OnceCell, ops::Deref};
 
 pub use bytes::{StorageBytes, StorageString};
 pub use cache::{
-    ClearStorageType, SimpleStorageType, StorageCache, StorageGuard, StorageGuardMut, StorageType,
+    Erasable, SimpleStorageType, StorageCache, StorageGuard, StorageGuardMut, StorageType,
 };
 pub use map::StorageMap;
 pub use vec::StorageVec;
@@ -122,8 +122,8 @@ impl<'a, const B: usize, const L: usize> SimpleStorageType<'a> for StorageUint<B
     }
 }
 
-impl<const B: usize, const L: usize> ClearStorageType for StorageUint<B, L> {
-    fn clear(&mut self) {
+impl<const B: usize, const L: usize> Erasable for StorageUint<B, L> {
+    fn erase(&mut self) {
         self.set(Self::Wraps::ZERO);
     }
 }
@@ -193,8 +193,8 @@ impl<'a, const B: usize, const L: usize> SimpleStorageType<'a> for StorageSigned
     }
 }
 
-impl<const B: usize, const L: usize> ClearStorageType for StorageSigned<B, L> {
-    fn clear(&mut self) {
+impl<const B: usize, const L: usize> Erasable for StorageSigned<B, L> {
+    fn erase(&mut self) {
         self.set(Self::Wraps::ZERO)
     }
 }
@@ -264,8 +264,8 @@ impl<'a, const N: usize> SimpleStorageType<'a> for StorageFixedBytes<N> {
     }
 }
 
-impl<const N: usize> ClearStorageType for StorageFixedBytes<N> {
-    fn clear(&mut self) {
+impl<const N: usize> Erasable for StorageFixedBytes<N> {
+    fn erase(&mut self) {
         self.set(Self::Wraps::ZERO)
     }
 }
@@ -335,8 +335,8 @@ impl<'a> SimpleStorageType<'a> for StorageBool {
     }
 }
 
-impl ClearStorageType for StorageBool {
-    fn clear(&mut self) {
+impl Erasable for StorageBool {
+    fn erase(&mut self) {
         self.set(false);
     }
 }
@@ -408,8 +408,8 @@ impl<'a> SimpleStorageType<'a> for StorageAddress {
     }
 }
 
-impl ClearStorageType for StorageAddress {
-    fn clear(&mut self) {
+impl Erasable for StorageAddress {
+    fn erase(&mut self) {
         self.set(Self::Wraps::ZERO);
     }
 }
@@ -481,8 +481,8 @@ impl<'a> SimpleStorageType<'a> for StorageBlockNumber {
     }
 }
 
-impl ClearStorageType for StorageBlockNumber {
-    fn clear(&mut self) {
+impl Erasable for StorageBlockNumber {
+    fn erase(&mut self) {
         self.set(0);
     }
 }
@@ -548,8 +548,8 @@ impl<'a> SimpleStorageType<'a> for StorageBlockHash {
     }
 }
 
-impl ClearStorageType for StorageBlockHash {
-    fn clear(&mut self) {
+impl Erasable for StorageBlockHash {
+    fn erase(&mut self) {
         self.set(Self::Wraps::ZERO);
     }
 }

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -2,7 +2,7 @@
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
 use super::{
-    ClearStorageType, SimpleStorageType, StorageCache, StorageGuard, StorageGuardMut, StorageType,
+    Erasable, SimpleStorageType, StorageCache, StorageGuard, StorageGuardMut, StorageType,
 };
 use crate::crypto;
 use alloy_primitives::U256;
@@ -208,25 +208,25 @@ impl<'a, S: SimpleStorageType<'a>> StorageVec<S> {
     }
 }
 
-impl<S: ClearStorageType> StorageVec<S> {
+impl<S: Erasable> StorageVec<S> {
     /// Removes and erases the last element of the vector.
-    pub fn clear_last(&mut self) {
+    pub fn erase_last(&mut self) {
         if self.is_empty() {
             return;
         }
         let index = self.len() - 1;
         unsafe {
-            self.accessor_unchecked(index).clear();
+            self.accessor_unchecked(index).erase();
             self.set_len(index);
         }
     }
 }
 
-impl<S: ClearStorageType> ClearStorageType for StorageVec<S> {
-    fn clear(&mut self) {
+impl<S: Erasable> Erasable for StorageVec<S> {
+    fn erase(&mut self) {
         for i in 0..self.len() {
             let mut store = unsafe { self.accessor_unchecked(i) };
-            store.clear()
+            store.erase()
         }
         self.truncate(0);
     }


### PR DESCRIPTION
Renames `ClearStorageType` to the friendlier `Erasable`. 

The `.clear()` and `.clear_last()` functions are now `.erase() and .erase_last()`.