### PR TITLE
Fix abi export

### DIFF
--- a/stylus-proc/src/methods/external.rs
+++ b/stylus-proc/src/methods/external.rs
@@ -150,7 +150,7 @@ pub fn external(_attr: TokenStream, input: TokenStream) -> TokenStream {
             let comma = (i > 0).then_some(", ").unwrap_or_default();
             let name = ident.as_ref().map(ToString::to_string).unwrap_or_default();
             quote! {
-                write!(f, "{}{}{}", #comma, <#ty as AbiType>::EXPORT_ABI_RET, underscore_if_sol(#name))?;
+                write!(f, "{}{}{}", #comma, <#ty as AbiType>::EXPORT_ABI_ARG, underscore_if_sol(#name))?;
             }
         });
         let sol_outs = match &method.sig.output {

--- a/stylus-sdk/src/abi/const_string.rs
+++ b/stylus-sdk/src/abi/const_string.rs
@@ -62,7 +62,15 @@ impl ConstString {
             data[position] = b'0' + (number % 10) as u8;
             number /= 10;
         }
-        ConstString { data, len: digits }
+        Self { data, len: digits }
+    }
+
+    /// Selects a [`ConstString`] depending on the condition.
+    pub const fn select(cond: bool, true_value: &str, false_value: &str) -> Self {
+        match cond {
+            true => Self::new(true_value),
+            false => Self::new(false_value),
+        }
     }
 
     /// Clones a [`ConstString`] in a `const` context.

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -53,6 +53,9 @@ pub trait AbiType {
 
     /// String to use when the type is an interface method return value.
     const EXPORT_ABI_RET: ConstString = Self::ABI;
+
+    /// Whether the type is allowed in calldata
+    const CAN_BE_CALLDATA: bool = true;
 }
 
 /// Generates a function selector for the given method and its args.


### PR DESCRIPTION
Fixes abi export to properly handle nested compound types.
```solidity
interface Sha256Hasher {
    function sha256(bytes calldata a, string[] memory b, uint8[4] calldata c, bytes[2] calldata d, bool[][2] memory e) external view returns (string memory, bytes32);
}
```