### PR TITLE
Feature-gate `console_log`

### DIFF
--- a/stylus-sdk/src/debug.rs
+++ b/stylus-sdk/src/debug.rs
@@ -4,6 +4,7 @@
 use crate::hostio;
 
 /// Prints a UTF-8 encoded string to the console. Only available in debug mode.
+#[cfg(feature = "debug")]
 pub fn console_log<T: AsRef<str>>(text: T) {
     let text = text.as_ref();
     unsafe { hostio::log_txt(text.as_ptr(), text.len()) };


### PR DESCRIPTION
Puts `console_log`, the underlying method of the `console!` macro behind the same `debug` feature flag
