### PR TITLE
Simplify fixed bytes

### DIFF
--- a/stylus-proc/src/types.rs
+++ b/stylus-proc/src/types.rs
@@ -80,7 +80,10 @@ pub fn solidity_type_info(ty: &Type) -> (Cow<'static, str>, Cow<'static, str>) {
         Type::Address(_, _) => simple!(Address),
         Type::String(_) => simple!(String),
         Type::Bytes(_) => simple!(Bytes),
-        Type::FixedBytes(_, size) => (path!("FixedBytes<{size}>"), abi!("bytes[{size}]")),
+        Type::FixedBytes(_, size) => (
+            "stylus_sdk::abi::FixedBytesSolType<{size}>".into(),
+            abi!("bytes[{size}]"),
+        ),
         Type::Uint(_, size) => {
             let size = size.unwrap_or(NonZeroU16::new(256).unwrap());
             (path!("Uint<{size}>"), abi!("uint{size}"))

--- a/stylus-sdk/src/abi/fixed_bytes.rs
+++ b/stylus-sdk/src/abi/fixed_bytes.rs
@@ -3,56 +3,12 @@
 
 use super::{AbiType, ConstString};
 use alloc::borrow::Cow;
+use alloy_primitives::FixedBytes;
 use alloy_sol_types::{
     sol_data::{ByteCount, SupportedFixedBytes},
     token::WordToken,
     Encodable, SolType, Word,
 };
-use core::ops::{Deref, DerefMut};
-
-/// Represents a [`fixed-size byte array`] in Solidity.
-///
-/// [`fixed-size byte array`]: https://docs.soliditylang.org/en/v0.8.21/types.html#fixed-size-byte-arrays
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-pub struct FixedBytes<const N: usize>(pub [u8; N]);
-
-impl<const N: usize> From<FixedBytes<N>> for [u8; N] {
-    fn from(value: FixedBytes<N>) -> Self {
-        value.0
-    }
-}
-
-impl<const N: usize> From<[u8; N]> for FixedBytes<N> {
-    fn from(b: [u8; N]) -> Self {
-        Self(b)
-    }
-}
-
-impl<const N: usize> Deref for FixedBytes<N> {
-    type Target = [u8; N];
-
-    fn deref(&self) -> &[u8; N] {
-        &self.0
-    }
-}
-
-impl<const N: usize> DerefMut for FixedBytes<N> {
-    fn deref_mut(&mut self) -> &mut [u8; N] {
-        &mut self.0
-    }
-}
-
-impl<const N: usize> AsRef<[u8]> for FixedBytes<N> {
-    fn as_ref(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl<const N: usize> AsMut<[u8]> for FixedBytes<N> {
-    fn as_mut(&mut self) -> &mut [u8] {
-        &mut self.0
-    }
-}
 
 pub struct FixedBytesSolType<const N: usize>;
 

--- a/stylus-sdk/src/abi/impls.rs
+++ b/stylus-sdk/src/abi/impls.rs
@@ -5,6 +5,9 @@ use super::{AbiType, ConstString};
 use alloy_primitives::{Address, Signed, Uint};
 use alloy_sol_types::sol_data::{self, IntBitCount, SupportedInt};
 
+#[cfg(test)]
+use alloy_primitives::FixedBytes;
+
 /// Generates a test to ensure the two-way relationship between Rust Types and Sol Types is bijective.
 macro_rules! test_type {
     ($name:tt, $as_arg:expr, $($ty:tt)*) => {
@@ -140,11 +143,7 @@ test_type!(
     Vec<alloy_primitives::U256>
 );
 test_type!(vec_of_bytes, "bytes[] memory", Vec<super::Bytes>);
-test_type!(
-    vec_of_fixed_bytes,
-    "bytes18[] memory",
-    Vec<super::FixedBytes<18>>
-);
+test_type!(vec_of_fixed_bytes, "bytes18[] memory", Vec<FixedBytes<18>>);
 
 impl<T: AbiType, const N: usize> AbiType for [T; N] {
     type SolType = sol_data::FixedArray<T::SolType, N>;
@@ -170,7 +169,7 @@ test_type!(array_of_nested_u32s, "uint32[2][4] calldata", [[u32; 2]; 4]);
 test_type!(
     array_of_fixed_bytes,
     "bytes32[] memory",
-    Vec<super::FixedBytes<32>>
+    Vec<FixedBytes<32>>
 );
 
 impl AbiType for () {
@@ -237,7 +236,7 @@ test_type!(
         u8,
         Vec<alloy_primitives::U256>,
         super::Bytes,
-        super::FixedBytes<2>,
+        FixedBytes<2>,
         [Vec<bool>; 8],
     )
 );

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -7,7 +7,7 @@ use core::borrow::BorrowMut;
 
 pub use bytes::{Bytes, BytesSolType};
 pub use const_string::ConstString;
-pub use fixed_bytes::{FixedBytes, FixedBytesSolType};
+pub use fixed_bytes::FixedBytesSolType;
 
 #[cfg(feature = "export-abi")]
 pub use export::GenerateAbi;


### PR DESCRIPTION
This PR removes our custom `FixedBytes` type in favor of Alloy's. Ideally we'd also drop `FixedBytesSolType`, but that'd require upstream update the corresponding `SolType` implementation.
- https://github.com/alloy-rs/core/issues/259

This is a breaking change and will require a version bump to `0.2.0`.

This will allow one to more easily do the following without importing a second `FixedBytes` type.
```rs
pub fn root(&self) -> Result<B256, Vec<u8>> {
    Ok(self.root.get().into())
}
```