### PR TITLE
fix: sol_interface! macro with no arguments

### DIFF
--- a/stylus-proc/src/calls/mod.rs
+++ b/stylus-proc/src/calls/mod.rs
@@ -140,7 +140,11 @@ pub fn sol_interface(input: TokenStream) -> TokenStream {
                     Result<<#return_type as #sol_type>::RustType, stylus_sdk::call::Error>
                 {
                     use alloc::vec;
-                    let args = <(#(#sol_args),*,) as #sol_type>::encode(&(#(#rust_arg_names,)*));
+                    let args = if sol_args.is_empty() {
+                        as #sol_type>::encode(&())
+                    } else {
+                        <(#(#sol_args),*) as #sol_type>::encode(&(#(#rust_arg_names),*))
+                    };
                     let mut calldata = vec![#selector0, #selector1, #selector2, #selector3];
                     calldata.extend(args);
                     let returned = #call(context, self.address, &calldata)?;


### PR DESCRIPTION
I think sol_interface! is broken if you pass in no arguments due to a leading comma
```
sol_interface! {
    interface A {
        function B() view returns (address);
    }
}
error: expected type, found `,`
  --> src/main.rs:22:1
   |
22 | / sol_interface! {
23 | |     interface A {
24 | |         function B() view returns (address);
25 | |     }
26 | | }
   | |_^ expected type
   |
```
This change to the macro should fix it (untested, I couldn't get a testing environment to work)
