### PR TITLE
Fix `sol_interface!` when expanding empty args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,24 +434,6 @@ dependencies = [
 
 [[package]]
 name = "stylus-proc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ed6e3a897eea8ef2e19836b622fde7a9b114009f7eeca00d26a232e70603d0"
-dependencies = [
- "alloy-primitives",
- "alloy-sol-types",
- "convert_case 0.6.0",
- "lazy_static",
- "proc-macro2",
- "quote",
- "regex",
- "sha3",
- "syn 1.0.109",
- "syn-solidity",
-]
-
-[[package]]
-name = "stylus-proc"
 version = "0.2.0"
 dependencies = [
  "alloy-primitives",
@@ -480,7 +462,7 @@ dependencies = [
  "paste",
  "regex",
  "sha3",
- "stylus-proc 0.1.2",
+ "stylus-proc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ convert_case = "0.6.0"
 
 # members
 stylus-sdk = { path = "stylus-sdk" }
-stylus-proc = { path = "stylus-proc" }
+stylus-proc = { path = "stylus-proc", version = "0.2.0" }

--- a/stylus-proc/src/calls/mod.rs
+++ b/stylus-proc/src/calls/mod.rs
@@ -140,7 +140,7 @@ pub fn sol_interface(input: TokenStream) -> TokenStream {
                     Result<<#return_type as #sol_type>::RustType, stylus_sdk::call::Error>
                 {
                     use alloc::vec;
-                    let args = <(#(#sol_args),*,) as #sol_type>::encode(&(#(#rust_arg_names,)*));
+                    let args = <(#(#sol_args,)*) as #sol_type>::encode(&(#(#rust_arg_names,)*));
                     let mut calldata = vec![#selector0, #selector1, #selector2, #selector3];
                     calldata.extend(args);
                     let returned = #call(context, self.address, &calldata)?;

--- a/stylus-proc/src/calls/mod.rs
+++ b/stylus-proc/src/calls/mod.rs
@@ -76,7 +76,7 @@ pub fn sol_interface(input: TokenStream) -> TokenStream {
                     quote! { stylus_sdk::call::static_call },
                 ),
                 Write => (
-                    quote! { impl stylus_sdk::call::WriteCallContext },
+                    quote! { impl stylus_sdk::call::NonPayableCallContext },
                     quote! { stylus_sdk::call::call },
                 ),
                 Payable => (

--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -23,7 +23,7 @@ regex = { workspace = true, optional = true }
 fnv.workspace = true
 
 # local deps
-stylus-proc = "0.1.2"
+stylus-proc.workspace = true
 
 [dev-dependencies]
 paste.workspace = true


### PR DESCRIPTION
Fixes `sol_interface!` when given expanding args. 
We'd mistakenly expanded it to `(,)`, rather than `()`.

```rs
sol_interface! {
    interface IClass {
        function empty();
    }
}
```

Solves: #44 