### PR TITLE
Add an "I" before interface names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-proc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -450,7 +450,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-sdk"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["stylus-sdk", "stylus-proc"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Offchain Labs"]
 license = "MIT OR Apache-2.0"

--- a/stylus-proc/src/methods/external.rs
+++ b/stylus-proc/src/methods/external.rs
@@ -272,7 +272,7 @@ pub fn external(_attr: TokenStream, input: TokenStream) -> TokenStream {
     is_clause.extend(inherits.iter().enumerate().map(|(i, ty)| {
         let comma = (i > 0).then_some(", ").unwrap_or_default();
         quote! {
-            write!(f, "{}{}", #comma, <#ty as GenerateAbi>::NAME)?;
+            write!(f, "{}I{}", #comma, <#ty as GenerateAbi>::NAME)?;
         }
     }));
 
@@ -285,7 +285,7 @@ pub fn external(_attr: TokenStream, input: TokenStream) -> TokenStream {
                 use stylus_sdk::abi::internal::write_solidity_returns;
                 use stylus_sdk::abi::export::{underscore_if_sol};
                 #(#inherited_abis)*
-                write!(f, "interface {}", #name)?;
+                write!(f, "interface I{}", #name)?;
                 #is_clause
                 write!(f, " {{")?;
                 #abi


### PR DESCRIPTION
Updates abi exports to include an "I" before interface names