### PR TITLE
Disable storage cache

### DIFF
--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -17,10 +17,12 @@ derivative.workspace = true
 hex = { workspace = true, default-features = false, features = ["alloc"] }
 keccak-const.workspace = true
 lazy_static.workspace = true
+
+# export-abi
 regex = { workspace = true, optional = true }
 
-# data structures
-fnv.workspace = true
+# storage-cache
+fnv = { workspace = true, optional = true }
 
 # local deps
 stylus-proc.workspace = true
@@ -30,7 +32,7 @@ paste.workspace = true
 sha3.workspace = true
 
 [features]
-default = ["storage_cache"]
+default = ["storage-cache"]
 export-abi = ["debug", "regex", "stylus-proc/export-abi"]
 debug = []
-storage_cache = []
+storage-cache = ["fnv"]

--- a/stylus-sdk/src/call/mod.rs
+++ b/stylus-sdk/src/call/mod.rs
@@ -1,11 +1,16 @@
 // Copyright 2022-2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
-use crate::storage::{StorageCache, TopLevelStorage};
+use crate::storage::TopLevelStorage;
 use alloy_primitives::{Address, U256};
 use core::sync::atomic::{AtomicBool, Ordering};
 
 pub use self::{context::Context, error::Error, raw::RawCall, traits::*};
+
+pub(crate) use raw::CachePolicy;
+
+#[cfg(feature = "storage-cache")]
+use crate::storage::Storage;
 
 mod context;
 mod error;
@@ -45,9 +50,10 @@ pub fn static_call(
     to: Address,
     data: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    // flush storage to persist changes, but don't invalidate the cache
+    #[cfg(feature = "storage-cache")]
     if reentrancy_enabled() {
-        StorageCache::flush();
+        // flush storage to persist changes, but don't invalidate the cache
+        Storage::flush();
     }
     unsafe {
         RawCall::new_static()
@@ -59,9 +65,10 @@ pub fn static_call(
 
 /// Calls the contract at the given address.
 pub fn call(context: impl MutatingCallContext, to: Address, data: &[u8]) -> Result<Vec<u8>, Error> {
-    // clear the storage to persist changes, invalidating the cache
+    #[cfg(feature = "storage-cache")]
     if reentrancy_enabled() {
-        StorageCache::clear();
+        // clear the storage to persist changes, invalidating the cache
+        Storage::clear();
     }
     unsafe {
         RawCall::new_with_value(context.value())

--- a/stylus-sdk/src/deploy/raw.rs
+++ b/stylus-sdk/src/deploy/raw.rs
@@ -1,12 +1,15 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
-use alloy_primitives::{Address, B256, U256};
-
 use crate::{
+    call::CachePolicy,
     contract::{read_return_data, RETURN_DATA_LEN},
     hostio,
 };
+use alloy_primitives::{Address, B256, U256};
+
+#[cfg(feature = "storage-cache")]
+use crate::storage::StorageCache;
 
 /// Mechanism for performing raw deploys of other contracts.
 #[derive(Clone, Default)]
@@ -15,6 +18,8 @@ pub struct RawDeploy {
     salt: Option<B256>,
     offset: usize,
     size: Option<usize>,
+    #[allow(unused)]
+    cache_policy: CachePolicy,
 }
 
 impl RawDeploy {
@@ -55,6 +60,22 @@ impl RawDeploy {
         self.limit_revert_data(0, 0)
     }
 
+    /// Write all cached values to persistent storage before the init code.
+    #[cfg(feature = "storage-cache")]
+    pub fn flush_storage_cache(mut self) -> Self {
+        if self.cache_policy < CachePolicy::Flush {
+            self.cache_policy = CachePolicy::Flush;
+        }
+        self
+    }
+
+    /// Flush and clear the storage cache before the init code.
+    #[cfg(feature = "storage-cache")]
+    pub fn clear_storage_cache(mut self) -> Self {
+        self.cache_policy = CachePolicy::Clear;
+        self
+    }
+
     /// Performs a raw deploy of another contract with the given `endowment` and init `code`.
     /// Returns the address of the newly deployed contract, or the error data in case of failure.
     ///
@@ -67,6 +88,13 @@ impl RawDeploy {
     /// For extra flexibility, this method does not clear the global storage cache.
     /// See [`StorageCache::flush`] and [`StorageCache::clear`] for more information.
     pub unsafe fn deploy(self, code: &[u8], endowment: U256) -> Result<Address, Vec<u8>> {
+        #[cfg(feature = "storage-cache")]
+        match self.cache_policy {
+            CachePolicy::Clear => StorageCache::clear(),
+            CachePolicy::Flush => StorageCache::flush(),
+            CachePolicy::DoNothing => {}
+        }
+
         let mut contract = Address::default();
         let mut revert_data_len = 0;
 

--- a/stylus-sdk/src/storage/cache.rs
+++ b/stylus-sdk/src/storage/cache.rs
@@ -1,30 +1,21 @@
 // Copyright 2022-2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
-use super::{load_bytes32, store_bytes32};
-use alloy_primitives::{FixedBytes, Signed, Uint, B256, U256};
-use core::{
-    marker::PhantomData,
-    ops::{Deref, DerefMut},
-    ptr,
-};
-#[cfg(feature = "storage_cache")]
+use super::{load_bytes32, store_bytes32, traits::GlobalStorage};
+use alloy_primitives::{B256, U256};
 use core::cell::UnsafeCell;
-use derivative::Derivative;
-#[cfg(feature = "storage_cache")]
 use fnv::FnvHashMap as HashMap;
-#[cfg(feature = "storage_cache")]
 use lazy_static::lazy_static;
 
 /// Global cache managing persistent storage operations.
-#[cfg(feature = "storage_cache")]
+///
+/// This is intended for most use cases. However, one may opt-out
+/// of this behavior by turning off default features and not enabling
+/// the `storage-cache` feature. Doing so will provide the [`EagerStorage`] type
+/// for managing state in the absence of caching.
 pub struct StorageCache(HashMap<U256, StorageWord>);
 
-#[cfg(not (feature = "storage_cache"))]
-pub struct StorageCache;
-
 /// Represents the EVM word at a given key.
-#[cfg(feature = "storage_cache")]
 pub struct StorageWord {
     /// The current value of the slot.
     value: B256,
@@ -32,7 +23,6 @@ pub struct StorageWord {
     known: Option<B256>,
 }
 
-#[cfg(feature = "storage_cache")]
 impl StorageWord {
     /// Creates a new slot from a known value in the EVM state trie.
     fn new_known(known: B256) -> Self {
@@ -58,226 +48,37 @@ struct ForceSync<T>(T);
 
 unsafe impl<T> Sync for ForceSync<T> {}
 
-#[cfg(feature = "storage_cache")]
 lazy_static! {
     /// Global cache managing persistent storage operations.
     static ref CACHE: ForceSync<UnsafeCell<StorageCache>> = ForceSync(UnsafeCell::new(StorageCache(HashMap::default())));
 }
 
 /// Mutably accesses the global cache's hashmap
-#[cfg(feature = "storage_cache")]
 macro_rules! cache {
     () => {
         unsafe { &mut (*CACHE.0.get()).0 }
     };
 }
 
-impl StorageCache {
-    /// Retrieves `N ≤ 32` bytes from persistent storage, performing [`SLOAD`]'s only as needed.
-    /// The bytes are read from slot `key`, starting `offset` bytes from the left.
-    /// Note that the bytes must exist within a single, 32-byte EVM word.
-    ///
-    /// # Safety
-    ///
-    /// UB if the read would cross a word boundary.
-    /// May become safe when Rust stabilizes [`generic_const_exprs`].
-    ///
-    /// [`SLOAD`]: https://www.evm.codes/#54
-    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    pub unsafe fn get<const N: usize>(key: U256, offset: usize) -> FixedBytes<N> {
-        debug_assert!(N + offset <= 32);
-        let word = Self::get_word(key);
-        let value = &word[offset..][..N];
-        FixedBytes::from_slice(value)
-    }
-
-    /// Retrieves a [`Uint`] from persistent storage, performing [`SLOAD`]'s only as needed.
-    /// The integer's bytes are read from slot `key`, starting `offset` bytes from the left.
-    /// Note that the bytes must exist within a single, 32-byte EVM word.
-    ///
-    /// # Safety
-    ///
-    /// UB if the read would cross a word boundary.
-    /// May become safe when Rust stabilizes [`generic_const_exprs`].
-    ///
-    /// [`SLOAD`]: https://www.evm.codes/#54
-    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    pub unsafe fn get_uint<const B: usize, const L: usize>(key: U256, offset: usize) -> Uint<B, L> {
-        debug_assert!(B / 8 + offset <= 32);
-        let word = Self::get_word(key);
-        let value = &word[offset..][..B / 8];
-        Uint::try_from_be_slice(value).unwrap()
-    }
-
-    /// Retrieves a [`u8`] from persistent storage, performing [`SLOAD`]'s only as needed.
-    /// The byte is read from slot `key`, starting `offset` bytes from the left.
-    ///
-    /// # Safety
-    ///
-    /// UB if the read is out of bounds.
-    /// May become safe when Rust stabilizes [`generic_const_exprs`].
-    ///
-    /// [`SLOAD`]: https://www.evm.codes/#54
-    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    pub unsafe fn get_byte(key: U256, offset: usize) -> u8 {
-        debug_assert!(offset <= 32);
-        let word = Self::get::<1>(key, offset);
-        word[0]
-    }
-
-    /// Retrieves a [`Signed`] from persistent storage, performing [`SLOAD`]'s only as needed.
-    /// The integer's bytes are read from slot `key`, starting `offset` bytes from the left.
-    /// Note that the bytes must exist within a single, 32-byte EVM word.
-    ///
-    /// # Safety
-    ///
-    /// UB if the read would cross a word boundary.
-    /// May become safe when Rust stabilizes [`generic_const_exprs`].
-    ///
-    /// [`SLOAD`]: https://www.evm.codes/#54
-    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    pub unsafe fn get_signed<const B: usize, const L: usize>(
-        key: U256,
-        offset: usize,
-    ) -> Signed<B, L> {
-        Signed::from_raw(Self::get_uint(key, offset))
-    }
-
-    /// Retrieves a 32-byte EVM word from persistent storage, performing [`SLOAD`]'s only as needed.
-    ///
-    /// [`SLOAD`]: https://www.evm.codes/#54
-    #[cfg(feature = "storage_cache")]
-    pub fn get_word(key: U256) -> B256 {
+impl GlobalStorage for StorageCache {
+    fn get_word(key: U256) -> B256 {
         cache!()
             .entry(key)
-            .or_insert_with(|| unsafe { StorageWord::new_known(load_bytes32(key)) }).value
+            .or_insert_with(|| unsafe { StorageWord::new_known(load_bytes32(key)) })
+            .value
     }
 
-    #[cfg(not (feature = "storage_cache"))]
-    pub fn get_word(key: U256) -> B256 {
-        unsafe { load_bytes32(key) }
-    }
-
-    /// Writes `N ≤ 32` bytes to persistent storage, performing [`SSTORE`]'s only as needed.
-    /// The bytes are written to slot `key`, starting `offset` bytes from the left.
-    /// Note that the bytes must be written to a single, 32-byte EVM word.
-    ///
-    /// # Safety
-    ///
-    /// UB if the write would cross a word boundary.
-    /// Aliases if called during the lifetime an overlapping accessor.
-    ///
-    /// [`SSTORE`]: https://www.evm.codes/#55
-    pub unsafe fn set<const N: usize>(key: U256, offset: usize, value: FixedBytes<N>) {
-        debug_assert!(N + offset <= 32);
-
-        if N == 32 {
-            return Self::set_word(key, FixedBytes::from_slice(value.as_slice()));
-        }
-
-        let mut word = Self::get_word(key);
-
-        let dest = word[offset..].as_mut_ptr();
-        ptr::copy(value.as_ptr(), dest, N);
-
-        Self::set_word(key, word);
-    }
-
-    /// Writes a [`Uint`] to persistent storage, performing [`SSTORE`]'s only as needed.
-    /// The integer's bytes are written to slot `key`, starting `offset` bytes from the left.
-    /// Note that the bytes must be written to a single, 32-byte EVM word.
-    ///
-    /// # Safety
-    ///
-    /// UB if the write would cross a word boundary.
-    /// Aliases if called during the lifetime an overlapping accessor.
-    ///
-    /// [`SSTORE`]: https://www.evm.codes/#55
-    pub unsafe fn set_uint<const B: usize, const L: usize>(
-        key: U256,
-        offset: usize,
-        value: Uint<B, L>,
-    ) {
-        debug_assert!(B / 8 + offset <= 32);
-
-        if B == 256 {
-            return Self::set_word(key, FixedBytes::from_slice(&value.to_be_bytes::<32>()));
-        }
-
-        let mut word = Self::get_word(key);
-
-        let value = value.to_be_bytes_vec();
-        let dest = word[offset..].as_mut_ptr();
-        ptr::copy(value.as_ptr(), dest, B / 8);
-        Self::set_word(key, word);
-    }
-
-    /// Writes a [`Signed`] to persistent storage, performing [`SSTORE`]'s only as needed.
-    /// The bytes are written to slot `key`, starting `offset` bytes from the left.
-    /// Note that the bytes must be written to a single, 32-byte EVM word.
-    ///
-    /// # Safety
-    ///
-    /// UB if the write would cross a word boundary.
-    /// Aliases if called during the lifetime an overlapping accessor.
-    ///
-    /// [`SSTORE`]: https://www.evm.codes/#55
-    pub unsafe fn set_signed<const B: usize, const L: usize>(
-        key: U256,
-        offset: usize,
-        value: Signed<B, L>,
-    ) {
-        Self::set_uint(key, offset, value.into_raw())
-    }
-
-    /// Writes a [`u8`] to persistent storage, performing [`SSTORE`]'s only as needed.
-    /// The byte is written to slot `key`, starting `offset` bytes from the left.
-    ///
-    /// # Safety
-    ///
-    /// UB if the write is out of bounds.
-    /// Aliases if called during the lifetime an overlapping accessor.
-    ///
-    /// [`SSTORE`]: https://www.evm.codes/#55
-    pub unsafe fn set_byte(key: U256, offset: usize, value: u8) {
-        let fixed = FixedBytes::from_slice(&[value]);
-        StorageCache::set::<1>(key, offset, fixed)
-    }
-
-    /// Stores a 32-byte EVM word to persistent storage, performing [`SSTORE`]'s only as needed.
-    ///
-    /// # Safety
-    ///
-    /// Aliases if called during the lifetime an overlapping accessor.
-    ///
-    /// [`SSTORE`]: https://www.evm.codes/#55
-    #[cfg(feature = "storage_cache")]
-    pub unsafe fn set_word(key: U256, value: B256) {
+    unsafe fn set_word(key: U256, value: B256) {
         cache!().insert(key, StorageWord::new_unknown(value));
     }
+}
 
-    #[cfg(not (feature = "storage_cache"))]
-    pub unsafe fn set_word(key: U256, value: B256) {
-        store_bytes32(key, value);
-    }
-
-    /// Clears the 32-byte word at the given key, performing [`SSTORE`]'s only as needed.
-    ///
-    /// # Safety
-    ///
-    /// Aliases if called during the lifetime an overlapping accessor.
-    ///
-    /// [`SSTORE`]: https://www.evm.codes/#55
-    pub unsafe fn clear_word(key: U256) {
-        Self::set_word(key, B256::ZERO)
-    }
-
+impl StorageCache {
     /// Write all cached values to persistent storage.
     /// Note: this operation retains [`SLOAD`] information for optimization purposes.
     /// If reentrancy is possible, use [`StorageCache::clear`].
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
-    #[cfg(feature = "storage_cache")]
     pub fn flush() {
         for (key, entry) in cache!() {
             if entry.dirty() {
@@ -286,180 +87,9 @@ impl StorageCache {
         }
     }
 
-    #[cfg(not (feature = "storage_cache"))]
-    pub fn flush() {}
-
     /// Flush and clear the storage cache.
-    #[cfg(feature = "storage_cache")]
     pub fn clear() {
         StorageCache::flush();
         cache!().clear();
-    }
-
-    #[cfg(not (feature = "storage_cache"))]
-    pub fn clear() {}
-}
-
-/// Accessor trait that lets a type be used in persistent storage.
-/// Users can implement this trait to add novel data structures to their contract definitions.
-/// The Stylus SDK by default provides only solidity types, which are represented [`the same way`].
-///
-/// [`the same way`]: https://docs.soliditylang.org/en/v0.8.15/internals/layout_in_storage.html
-pub trait StorageType: Sized {
-    /// For primative types, this is the type being stored.
-    /// For collections, this is the [`StorageType`] being collected.
-    type Wraps<'a>: 'a
-    where
-        Self: 'a;
-
-    /// Mutable accessor to the type being stored.
-    type WrapsMut<'a>: 'a
-    where
-        Self: 'a;
-
-    /// The number of bytes in a slot needed to represent the type. Must not exceed 32.
-    /// For types larger than 32 bytes that are stored inline with a struct's fields,
-    /// set this to 32 and return the full size in [`StorageType::new`].
-    ///
-    /// For implementing collections, see how Solidity slots are assigned for [`Arrays and Maps`] and their
-    /// Stylus equivalents [`StorageVec`] and [`StorageMap`].
-    /// For multi-word, but still-fixed-size types, see the implementations for structs and [`StorageArray`].
-    ///
-    /// [`Arrays and Maps`]: https://docs.soliditylang.org/en/v0.8.15/internals/layout_in_storage.html#mappings-and-dynamic-arrays
-    const SLOT_BYTES: usize = 32;
-
-    /// The number of words this type must fill. For primitives this is always 0.
-    /// For complex types requiring more than one inline word, set this to the total size.
-    const REQUIRED_SLOTS: usize = 0;
-
-    /// Where in persistent storage the type should live. Although useful for framework designers
-    /// creating new storage types, most user programs shouldn't call this.
-    /// Note: implementations will have to be `const` once [`generic_const_exprs`] stabilizes.
-    ///
-    /// # Safety
-    ///
-    /// Aliases storage if two calls to the same slot and offset occur within the same lifetime.
-    ///
-    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    unsafe fn new(slot: U256, offset: u8) -> Self;
-
-    /// Load the wrapped type, consuming the accessor.
-    /// Note: most types have a `get` and/or `getter`, which don't consume `Self`.
-    fn load<'s>(self) -> Self::Wraps<'s>
-    where
-        Self: 's;
-
-    /// Load the wrapped mutable type, consuming the accessor.
-    /// Note: most types have a `set` and/or `setter`, which don't consume `Self`.
-    fn load_mut<'s>(self) -> Self::WrapsMut<'s>
-    where
-        Self: 's;
-}
-
-/// Trait for accessors that can be used to completely erase their underlying value.
-/// Note that some collections, like [`StorageMap`], don't implement this trait.
-pub trait Erase: StorageType {
-    /// Erase the value from persistent storage.
-    fn erase(&mut self);
-}
-
-/// Trait for simple accessors that store no more than their wrapped value.
-/// The type's representation must be entirely inline, or storage leaks become possible.
-/// Note: it is a logic error if erasure does anything more than writing the zero-value.
-pub trait SimpleStorageType<'a>: StorageType + Erase + Into<Self::Wraps<'a>>
-where
-    Self: 'a,
-{
-    /// Write the value to persistent storage.
-    fn set_by_wrapped(&mut self, value: Self::Wraps<'a>);
-}
-
-/// Trait for top-level storage types, usually implemented by proc macros.
-/// Top-level types are special in that their lifetimes track the entirety
-/// of all the EVM state-changes throughout a contract invocation.
-///
-/// To prevent storage aliasing during reentrancy, you must hold a reference
-/// to such a type when making an EVM call. This may change in the future
-/// for programs that prevent reentrancy.
-///
-/// # Safety
-///
-/// The type must be top-level to prevent storage aliasing.
-pub unsafe trait TopLevelStorage {}
-
-/// Binds a storage accessor to a lifetime to prevent aliasing.
-/// Because this type doesn't implement `DerefMut`, mutable methods on the accessor aren't available.
-/// For a mutable accessor, see [`StorageGuardMut`].
-#[derive(Derivative)]
-#[derivative(Debug = "transparent")]
-pub struct StorageGuard<'a, T: 'a> {
-    inner: T,
-    #[derivative(Debug = "ignore")]
-    marker: PhantomData<&'a T>,
-}
-
-impl<'a, T: 'a> StorageGuard<'a, T> {
-    /// Creates a new storage guard around an arbitrary type.
-    pub fn new(inner: T) -> Self {
-        Self {
-            inner,
-            marker: PhantomData,
-        }
-    }
-
-    /// Get the underlying `T` directly, bypassing the borrow checker.
-    ///
-    /// # Safety
-    ///
-    /// Enables storage aliasing.
-    pub unsafe fn into_raw(self) -> T {
-        self.inner
-    }
-}
-
-impl<'a, T: 'a> Deref for StorageGuard<'a, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-/// Binds a storage accessor to a lifetime to prevent aliasing.
-pub struct StorageGuardMut<'a, T: 'a> {
-    inner: T,
-    marker: PhantomData<&'a T>,
-}
-
-impl<'a, T: 'a> StorageGuardMut<'a, T> {
-    /// Creates a new storage guard around an arbitrary type.
-    pub fn new(inner: T) -> Self {
-        Self {
-            inner,
-            marker: PhantomData,
-        }
-    }
-
-    /// Get the underlying `T` directly, bypassing the borrow checker.
-    ///
-    /// # Safety
-    ///
-    /// Enables storage aliasing.
-    pub unsafe fn into_raw(self) -> T {
-        self.inner
-    }
-}
-
-impl<'a, T: 'a> Deref for StorageGuardMut<'a, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.inner
-    }
-}
-
-impl<'a, T: 'a> DerefMut for StorageGuardMut<'a, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.inner
     }
 }

--- a/stylus-sdk/src/storage/eager.rs
+++ b/stylus-sdk/src/storage/eager.rs
@@ -1,0 +1,23 @@
+// Copyright 2022-2023, Offchain Labs, Inc.
+// For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
+
+use super::{load_bytes32, store_bytes32, traits::GlobalStorage};
+use alloy_primitives::{B256, U256};
+
+/// Global accessor to persistent storage that doesn't use caching.
+///
+/// To instead use storage-caching optimizations, recompile with the
+/// `storage-cache` feature flag, which will provide the [`StorageCache`] type.
+///
+/// Note that individual primitive types may still include efficient caching.
+pub struct EagerStorage;
+
+impl GlobalStorage for EagerStorage {
+    fn get_word(key: U256) -> B256 {
+        unsafe { load_bytes32(key) }
+    }
+
+    unsafe fn set_word(key: U256, value: B256) {
+        store_bytes32(key, value);
+    }
+}

--- a/stylus-sdk/src/storage/map.rs
+++ b/stylus-sdk/src/storage/map.rs
@@ -3,7 +3,7 @@
 
 use crate::crypto;
 
-use super::{cache::Erase, SimpleStorageType, StorageGuard, StorageGuardMut, StorageType};
+use super::{Erase, SimpleStorageType, StorageGuard, StorageGuardMut, StorageType};
 use alloy_primitives::{Address, FixedBytes, Signed, Uint, B256, U160, U256};
 use core::marker::PhantomData;
 

--- a/stylus-sdk/src/storage/traits.rs
+++ b/stylus-sdk/src/storage/traits.rs
@@ -1,0 +1,364 @@
+// Copyright 2022-2023, Offchain Labs, Inc.
+// For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
+
+use alloy_primitives::{FixedBytes, Signed, Uint, B256, U256};
+use core::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+    ptr,
+};
+use derivative::Derivative;
+
+/// Accessor trait that lets a type be used in persistent storage.
+/// Users can implement this trait to add novel data structures to their contract definitions.
+/// The Stylus SDK by default provides only solidity types, which are represented [`the same way`].
+///
+/// [`the same way`]: https://docs.soliditylang.org/en/v0.8.15/internals/layout_in_storage.html
+pub trait StorageType: Sized {
+    /// For primative types, this is the type being stored.
+    /// For collections, this is the [`StorageType`] being collected.
+    type Wraps<'a>: 'a
+    where
+        Self: 'a;
+
+    /// Mutable accessor to the type being stored.
+    type WrapsMut<'a>: 'a
+    where
+        Self: 'a;
+
+    /// The number of bytes in a slot needed to represent the type. Must not exceed 32.
+    /// For types larger than 32 bytes that are stored inline with a struct's fields,
+    /// set this to 32 and return the full size in [`StorageType::new`].
+    ///
+    /// For implementing collections, see how Solidity slots are assigned for [`Arrays and Maps`] and their
+    /// Stylus equivalents [`StorageVec`] and [`StorageMap`].
+    /// For multi-word, but still-fixed-size types, see the implementations for structs and [`StorageArray`].
+    ///
+    /// [`Arrays and Maps`]: https://docs.soliditylang.org/en/v0.8.15/internals/layout_in_storage.html#mappings-and-dynamic-arrays
+    const SLOT_BYTES: usize = 32;
+
+    /// The number of words this type must fill. For primitives this is always 0.
+    /// For complex types requiring more than one inline word, set this to the total size.
+    const REQUIRED_SLOTS: usize = 0;
+
+    /// Where in persistent storage the type should live. Although useful for framework designers
+    /// creating new storage types, most user programs shouldn't call this.
+    /// Note: implementations will have to be `const` once [`generic_const_exprs`] stabilizes.
+    ///
+    /// # Safety
+    ///
+    /// Aliases storage if two calls to the same slot and offset occur within the same lifetime.
+    ///
+    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
+    unsafe fn new(slot: U256, offset: u8) -> Self;
+
+    /// Load the wrapped type, consuming the accessor.
+    /// Note: most types have a `get` and/or `getter`, which don't consume `Self`.
+    fn load<'s>(self) -> Self::Wraps<'s>
+    where
+        Self: 's;
+
+    /// Load the wrapped mutable type, consuming the accessor.
+    /// Note: most types have a `set` and/or `setter`, which don't consume `Self`.
+    fn load_mut<'s>(self) -> Self::WrapsMut<'s>
+    where
+        Self: 's;
+}
+
+/// Trait for accessors that can be used to completely erase their underlying value.
+/// Note that some collections, like [`StorageMap`], don't implement this trait.
+pub trait Erase: StorageType {
+    /// Erase the value from persistent storage.
+    fn erase(&mut self);
+}
+
+/// Trait for simple accessors that store no more than their wrapped value.
+/// The type's representation must be entirely inline, or storage leaks become possible.
+/// Note: it is a logic error if erasure does anything more than writing the zero-value.
+pub trait SimpleStorageType<'a>: StorageType + Erase + Into<Self::Wraps<'a>>
+where
+    Self: 'a,
+{
+    /// Write the value to persistent storage.
+    fn set_by_wrapped(&mut self, value: Self::Wraps<'a>);
+}
+
+/// Trait for top-level storage types, usually implemented by proc macros.
+/// Top-level types are special in that their lifetimes track the entirety
+/// of all the EVM state-changes throughout a contract invocation.
+///
+/// To prevent storage aliasing during reentrancy, you must hold a reference
+/// to such a type when making an EVM call. This may change in the future
+/// for programs that prevent reentrancy.
+///
+/// # Safety
+///
+/// The type must be top-level to prevent storage aliasing.
+pub unsafe trait TopLevelStorage {}
+
+/// Binds a storage accessor to a lifetime to prevent aliasing.
+/// Because this type doesn't implement `DerefMut`, mutable methods on the accessor aren't available.
+/// For a mutable accessor, see [`StorageGuardMut`].
+#[derive(Derivative)]
+#[derivative(Debug = "transparent")]
+pub struct StorageGuard<'a, T: 'a> {
+    inner: T,
+    #[derivative(Debug = "ignore")]
+    marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: 'a> StorageGuard<'a, T> {
+    /// Creates a new storage guard around an arbitrary type.
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            marker: PhantomData,
+        }
+    }
+
+    /// Get the underlying `T` directly, bypassing the borrow checker.
+    ///
+    /// # Safety
+    ///
+    /// Enables storage aliasing.
+    pub unsafe fn into_raw(self) -> T {
+        self.inner
+    }
+}
+
+impl<'a, T: 'a> Deref for StorageGuard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+/// Binds a storage accessor to a lifetime to prevent aliasing.
+pub struct StorageGuardMut<'a, T: 'a> {
+    inner: T,
+    marker: PhantomData<&'a T>,
+}
+
+impl<'a, T: 'a> StorageGuardMut<'a, T> {
+    /// Creates a new storage guard around an arbitrary type.
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            marker: PhantomData,
+        }
+    }
+
+    /// Get the underlying `T` directly, bypassing the borrow checker.
+    ///
+    /// # Safety
+    ///
+    /// Enables storage aliasing.
+    pub unsafe fn into_raw(self) -> T {
+        self.inner
+    }
+}
+
+impl<'a, T: 'a> Deref for StorageGuardMut<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a, T: 'a> DerefMut for StorageGuardMut<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+/// Trait for managing access to persistent storage.
+/// Notable implementations include the [`StorageCache`] and [`EagerStorage`] types.
+pub trait GlobalStorage {
+    /// Retrieves `N ≤ 32` bytes from persistent storage, performing [`SLOAD`]'s only as needed.
+    /// The bytes are read from slot `key`, starting `offset` bytes from the left.
+    /// Note that the bytes must exist within a single, 32-byte EVM word.
+    ///
+    /// # Safety
+    ///
+    /// UB if the read would cross a word boundary.
+    /// May become safe when Rust stabilizes [`generic_const_exprs`].
+    ///
+    /// [`SLOAD`]: https://www.evm.codes/#54
+    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
+    unsafe fn get<const N: usize>(key: U256, offset: usize) -> FixedBytes<N> {
+        debug_assert!(N + offset <= 32);
+        let word = Self::get_word(key);
+        let value = &word[offset..][..N];
+        FixedBytes::from_slice(value)
+    }
+
+    /// Retrieves a [`Uint`] from persistent storage, performing [`SLOAD`]'s only as needed.
+    /// The integer's bytes are read from slot `key`, starting `offset` bytes from the left.
+    /// Note that the bytes must exist within a single, 32-byte EVM word.
+    ///
+    /// # Safety
+    ///
+    /// UB if the read would cross a word boundary.
+    /// May become safe when Rust stabilizes [`generic_const_exprs`].
+    ///
+    /// [`SLOAD`]: https://www.evm.codes/#54
+    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
+    unsafe fn get_uint<const B: usize, const L: usize>(key: U256, offset: usize) -> Uint<B, L> {
+        debug_assert!(B / 8 + offset <= 32);
+        let word = Self::get_word(key);
+        let value = &word[offset..][..B / 8];
+        Uint::try_from_be_slice(value).unwrap()
+    }
+
+    /// Retrieves a [`Signed`] from persistent storage, performing [`SLOAD`]'s only as needed.
+    /// The integer's bytes are read from slot `key`, starting `offset` bytes from the left.
+    /// Note that the bytes must exist within a single, 32-byte EVM word.
+    ///
+    /// # Safety
+    ///
+    /// UB if the read would cross a word boundary.
+    /// May become safe when Rust stabilizes [`generic_const_exprs`].
+    ///
+    /// [`SLOAD`]: https://www.evm.codes/#54
+    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
+    unsafe fn get_signed<const B: usize, const L: usize>(key: U256, offset: usize) -> Signed<B, L> {
+        Signed::from_raw(Self::get_uint(key, offset))
+    }
+
+    /// Retrieves a [`u8`] from persistent storage, performing [`SLOAD`]'s only as needed.
+    /// The byte is read from slot `key`, starting `offset` bytes from the left.
+    ///
+    /// # Safety
+    ///
+    /// UB if the read is out of bounds.
+    /// May become safe when Rust stabilizes [`generic_const_exprs`].
+    ///
+    /// [`SLOAD`]: https://www.evm.codes/#54
+    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
+    unsafe fn get_byte(key: U256, offset: usize) -> u8 {
+        debug_assert!(offset <= 32);
+        let word = Self::get::<1>(key, offset);
+        word[0]
+    }
+
+    /// Retrieves a [`Signed`] from persistent storage, performing [`SLOAD`]'s only as needed.
+    /// The integer's bytes are read from slot `key`, starting `offset` bytes from the left.
+    /// Note that the bytes must exist within a single, 32-byte EVM word.
+    ///
+    /// # Safety
+    ///
+    /// UB if the read would cross a word boundary.
+    /// May become safe when Rust stabilizes [`generic_const_exprs`].
+    ///
+    /// [`SLOAD`]: https://www.evm.codes/#54
+    /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
+    fn get_word(key: U256) -> B256;
+
+    /// Writes `N ≤ 32` bytes to persistent storage, performing [`SSTORE`]'s only as needed.
+    /// The bytes are written to slot `key`, starting `offset` bytes from the left.
+    /// Note that the bytes must be written to a single, 32-byte EVM word.
+    ///
+    /// # Safety
+    ///
+    /// UB if the write would cross a word boundary.
+    /// Aliases if called during the lifetime an overlapping accessor.
+    ///
+    /// [`SSTORE`]: https://www.evm.codes/#55
+    unsafe fn set<const N: usize>(key: U256, offset: usize, value: FixedBytes<N>) {
+        debug_assert!(N + offset <= 32);
+
+        if N == 32 {
+            return Self::set_word(key, FixedBytes::from_slice(value.as_slice()));
+        }
+
+        let mut word = Self::get_word(key);
+
+        let dest = word[offset..].as_mut_ptr();
+        ptr::copy(value.as_ptr(), dest, N);
+
+        Self::set_word(key, word);
+    }
+
+    /// Writes a [`Uint`] to persistent storage, performing [`SSTORE`]'s only as needed.
+    /// The integer's bytes are written to slot `key`, starting `offset` bytes from the left.
+    /// Note that the bytes must be written to a single, 32-byte EVM word.
+    ///
+    /// # Safety
+    ///
+    /// UB if the write would cross a word boundary.
+    /// Aliases if called during the lifetime an overlapping accessor.
+    ///
+    /// [`SSTORE`]: https://www.evm.codes/#55
+    unsafe fn set_uint<const B: usize, const L: usize>(
+        key: U256,
+        offset: usize,
+        value: Uint<B, L>,
+    ) {
+        debug_assert!(B / 8 + offset <= 32);
+
+        if B == 256 {
+            return Self::set_word(key, FixedBytes::from_slice(&value.to_be_bytes::<32>()));
+        }
+
+        let mut word = Self::get_word(key);
+
+        let value = value.to_be_bytes_vec();
+        let dest = word[offset..].as_mut_ptr();
+        ptr::copy(value.as_ptr(), dest, B / 8);
+        Self::set_word(key, word);
+    }
+
+    /// Writes a [`Signed`] to persistent storage, performing [`SSTORE`]'s only as needed.
+    /// The bytes are written to slot `key`, starting `offset` bytes from the left.
+    /// Note that the bytes must be written to a single, 32-byte EVM word.
+    ///
+    /// # Safety
+    ///
+    /// UB if the write would cross a word boundary.
+    /// Aliases if called during the lifetime an overlapping accessor.
+    ///
+    /// [`SSTORE`]: https://www.evm.codes/#55
+    unsafe fn set_signed<const B: usize, const L: usize>(
+        key: U256,
+        offset: usize,
+        value: Signed<B, L>,
+    ) {
+        Self::set_uint(key, offset, value.into_raw())
+    }
+
+    /// Writes a [`u8`] to persistent storage, performing [`SSTORE`]'s only as needed.
+    /// The byte is written to slot `key`, starting `offset` bytes from the left.
+    ///
+    /// # Safety
+    ///
+    /// UB if the write is out of bounds.
+    /// Aliases if called during the lifetime an overlapping accessor.
+    ///
+    /// [`SSTORE`]: https://www.evm.codes/#55
+    unsafe fn set_byte(key: U256, offset: usize, value: u8) {
+        let fixed = FixedBytes::from_slice(&[value]);
+        Self::set::<1>(key, offset, fixed)
+    }
+
+    /// Stores a 32-byte EVM word to persistent storage, performing [`SSTORE`]'s only as needed.
+    ///
+    /// # Safety
+    ///
+    /// Aliases if called during the lifetime an overlapping accessor.
+    ///
+    /// [`SSTORE`]: https://www.evm.codes/#55
+    unsafe fn set_word(key: U256, value: B256);
+
+    /// Clears the 32-byte word at the given key, performing [`SSTORE`]'s only as needed.
+    ///
+    /// # Safety
+    ///
+    /// Aliases if called during the lifetime an overlapping accessor.
+    ///
+    /// [`SSTORE`]: https://www.evm.codes/#55
+    unsafe fn clear_word(key: U256) {
+        Self::set_word(key, B256::ZERO)
+    }
+}

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -1,7 +1,9 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
-use super::{Erase, SimpleStorageType, StorageCache, StorageGuard, StorageGuardMut, StorageType};
+use super::{
+    Erase, GlobalStorage, SimpleStorageType, Storage, StorageGuard, StorageGuardMut, StorageType,
+};
 use crate::crypto;
 use alloy_primitives::U256;
 use core::{cell::OnceCell, marker::PhantomData};
@@ -43,7 +45,7 @@ impl<S: StorageType> StorageVec<S> {
 
     /// Gets the number of elements stored.
     pub fn len(&self) -> usize {
-        let word: U256 = StorageCache::get_word(self.slot).into();
+        let word: U256 = Storage::get_word(self.slot).into();
         word.try_into().unwrap()
     }
 
@@ -55,7 +57,7 @@ impl<S: StorageType> StorageVec<S> {
     /// or any junk data left over from prior dirty operations.
     /// Note that [`StorageVec`] has unlimited capacity, so all lengths are valid.
     pub unsafe fn set_len(&mut self, len: usize) {
-        StorageCache::set_word(self.slot, U256::from(len).into())
+        Storage::set_word(self.slot, U256::from(len).into())
     }
 
     /// Gets an accessor to the element at a given index, if it exists.
@@ -199,7 +201,7 @@ impl<'a, S: SimpleStorageType<'a>> StorageVec<S> {
             let slot = self.index_slot(index).0;
             let words = S::REQUIRED_SLOTS.max(1);
             for i in 0..words {
-                unsafe { StorageCache::clear_word(slot + U256::from(i)) };
+                unsafe { Storage::clear_word(slot + U256::from(i)) };
             }
         }
         Some(value)


### PR DESCRIPTION
This PR applies a few refactors to enable a compilation mode without `StorageCache` and its `fnv` dependency.

When the default `storage-cache` feature is disabled, a new `EagerStorage` type becomes available for managing persistent state in the absence of caching. This reduces binary size for use cases where storage operations are rare, and allows for an eager style of programming.

Importantly, individual `StorageType` implementations may choose to do caching themselves. This is a reasonable tradeoff since it optimizes primitives without pulling in `fnv`.

Central to the implementation is a new `GlobalStorage` trait that both `EagerStorage` and `StorageCache` implement, reducing code duplication while using module-level cfg granularity.