### PR TITLE
Simplify calls & condition reentrancy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
+ "cfg-if",
  "convert_case 0.6.0",
  "lazy_static",
  "proc-macro2",
@@ -454,6 +455,7 @@ version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
+ "cfg-if",
  "derivative",
  "fnv",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.71.0"
 [workspace.dependencies]
 alloy-primitives = { version = "0.3.1", default-features = false , features = ["native-keccak"] }
 alloy-sol-types = { version = "0.3.1", default-features = false }
+cfg-if = "1.0.0"
 derivative = { version = "2.2.0", features = ["use_core"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 keccak-const = "0.2.0"

--- a/stylus-proc/Cargo.toml
+++ b/stylus-proc/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 [dependencies]
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
+cfg-if.workspace = true
 convert_case.workspace = true
 lazy_static.workspace = true
 proc-macro2.workspace = true
@@ -25,6 +26,7 @@ quote.workspace = true
 [features]
 export-abi = []
 storage-cache = []
+reentrant = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/stylus-proc/Cargo.toml
+++ b/stylus-proc/Cargo.toml
@@ -29,7 +29,7 @@ storage-cache = []
 reentrant = []
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["export-abi", "storage-cache"]
 
 [lib]
 proc-macro = true

--- a/stylus-proc/src/calls/mod.rs
+++ b/stylus-proc/src/calls/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
+use crate::types::solidity_type_info;
 use convert_case::{Case, Casing};
 use proc_macro::TokenStream;
 use proc_macro2::Ident;
@@ -8,8 +9,6 @@ use quote::quote;
 use sha3::{Digest, Keccak256};
 use std::borrow::Cow;
 use syn_solidity::{FunctionAttribute, Item, Mutability, SolIdent, Visibility};
-
-use crate::types::solidity_type_info;
 
 pub fn sol_interface(input: TokenStream) -> TokenStream {
     let input = match syn_solidity::parse(input) {

--- a/stylus-proc/src/lib.rs
+++ b/stylus-proc/src/lib.rs
@@ -185,7 +185,7 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// In the above, we're able to pass `&self` and `&mut self` because `Contract` implements
-/// [`TopLevelStorage`], which means that a reference to it entails access to the entirity of
+/// [`TopLevelStorage`], which means that a reference to it entails access to the entirety of
 /// the contract's state. This is the reason it is sound to make a call, since it ensures all
 /// cached values are invalidated and/or persisted to state at the right time.
 ///

--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -33,7 +33,7 @@ paste.workspace = true
 sha3.workspace = true
 
 [package.metadata.docs.rs]
-all-features = true
+features = ["default", "docs", "debug", "export-abi"]
 
 [features]
 default = ["storage-cache"]

--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 [dependencies]
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
+cfg-if.workspace = true
 derivative.workspace = true
 hex = { workspace = true, default-features = false, features = ["alloc"] }
 keccak-const.workspace = true
@@ -41,3 +42,4 @@ debug = []
 docs = []
 hostio = []
 storage-cache = ["fnv", "stylus-proc/storage-cache"]
+reentrant = ["stylus-proc/reentrant"]

--- a/stylus-sdk/src/abi/bytes.rs
+++ b/stylus-sdk/src/abi/bytes.rs
@@ -56,6 +56,8 @@ impl AsMut<[u8]> for Bytes {
 }
 
 /// Provides a corresponding [`SolType`] for an [`abi`] [`Bytes`].
+///
+/// [`abi`]: crate::abi
 pub struct BytesSolType;
 
 impl SolType for BytesSolType {

--- a/stylus-sdk/src/call/context.rs
+++ b/stylus-sdk/src/call/context.rs
@@ -1,23 +1,34 @@
 // Copyright 2022-2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
-use super::{CallContext, MutatingCallContext, NonPayableCallContext, StaticCallContext};
 use crate::storage::TopLevelStorage;
+
+use super::{CallContext, MutatingCallContext, NonPayableCallContext, StaticCallContext};
 use alloy_primitives::U256;
+use cfg_if::cfg_if;
 
 /// Enables configurable calls to other contracts.
 #[derive(Debug, Clone)]
-pub struct Context<S, const HAS_VALUE: bool = false> {
+pub struct Call<S, const HAS_VALUE: bool = false> {
     gas: u64,
-    value: U256,
-    _storage: S,
+    value: Option<U256>,
+    storage: S,
 }
 
-impl Context<(), false> {
-    /// Begin configuring a call, similar to how [`RawCall`](super::RawCall) and [`std::fs::OpenOptions`] work.
+impl<'a, S: TopLevelStorage> Call<&'a mut S, false>
+where
+    S: TopLevelStorage + 'a,
+{
+    /// Similar to [`new`], but intended for projects and libraries using reentrant patterns.
+    ///
+    /// [`new_in`] safeguards persistent storage by requiring a reference to a [`TopLevelStorage`] `struct`.
+    ///
+    /// Recall that [`TopLevelStorage`] is special in that a reference to it represents access to the entire
+    /// contract's state. So that it's sound to [`flush`] or [`clear`] the [`StorageCache`] when calling out
+    /// to other contracts, calls that may induce reentrancy require an `&` or `&mut` to one.
     ///
     /// ```no_run
-    /// use stylus_sdk::call::{Context, Error};
+    /// use stylus_sdk::call::{Call, Error};
     /// use stylus_sdk::{prelude::*, evm, msg, alloy_primitives::Address};
     /// extern crate alloc;
     ///
@@ -29,14 +40,56 @@ impl Context<(), false> {
     ///
     /// pub fn do_call(
     ///     storage: &mut impl TopLevelStorage,  // can be generic, but often just &mut self
-    ///     account: IService,
+    ///     account: IService,                   // serializes as an Address
     ///     user: Address,
     /// ) -> Result<String, Error> {
     ///
-    ///     let context = Context::new()
-    ///         .mutate(storage)             // make the call mutable (usually one passes self)
-    ///         .gas(evm::gas_left() / 2)    // limit to half the gas left
-    ///         .value(msg::value());        // set the callvalue
+    ///     let context = Call::new_in(storage)
+    ///         .gas(evm::gas_left() / 2)        // limit to half the gas left
+    ///         .value(msg::value());            // set the callvalue
+    ///
+    ///     account.make_payment(context, user)  // note the snake case
+    /// }
+    /// ```
+    ///
+    /// Projects that opt out of the [`StorageCache`] by disabling the `storage-cache` feature
+    /// may ignore this method.
+    ///
+    /// [`flush`]: StorageCache::flush
+    /// [`clear`]: StorageCache::clear
+    pub fn new_in(storage: &'a mut S) -> Self {
+        Self {
+            gas: u64::MAX,
+            value: None,
+            storage,
+        }
+    }
+}
+
+impl Default for Call<(), false> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Call<(), false> {
+    /// Begin configuring a call, similar to how [`RawCall`](super::RawCall) and [`std::fs::OpenOptions`] work.
+    ///
+    /// ```ignore
+    /// use stylus_sdk::call::{Call, Error};
+    /// use stylus_sdk::{prelude::*, evm, msg, alloy_primitives::Address};
+    /// extern crate alloc;
+    ///
+    /// sol_interface! {
+    ///     interface IService {
+    ///         function makePayment(address user) payable returns (string);
+    ///     }
+    /// }
+    ///
+    /// pub fn do_call(account: IService, user: Address) -> Result<String, Error> {
+    ///     let context = Call::new()
+    ///         .gas(evm::gas_left() / 2)        // limit to half the gas left
+    ///         .value(msg::value());            // set the callvalue
     ///
     ///     account.make_payment(context, user)  // note the snake case
     /// }
@@ -44,32 +97,13 @@ impl Context<(), false> {
     pub fn new() -> Self {
         Self {
             gas: u64::MAX,
-            value: U256::ZERO,
-            _storage: (),
+            value: None,
+            storage: (),
         }
     }
 }
 
-impl Default for Context<(), false> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<S, const HAS_VALUE: bool> Context<S, HAS_VALUE> {
-    /// Assigns a [`TopLevelStorage`] so that mutable methods can be called.
-    /// Note: enabling mutation will prevent calls to `pure` and `view` methods.
-    pub fn mutate<NewS: TopLevelStorage>(
-        self,
-        storage: &mut NewS,
-    ) -> Context<&mut NewS, HAS_VALUE> {
-        Context {
-            gas: self.gas,
-            value: self.value,
-            _storage: storage,
-        }
-    }
-
+impl<S, const HAS_VALUE: bool> Call<S, HAS_VALUE> {
     /// Amount of gas to supply the call.
     /// Values greater than the amount provided will be clipped to all gas left.
     pub fn gas(self, gas: u64) -> Self {
@@ -78,32 +112,20 @@ impl<S, const HAS_VALUE: bool> Context<S, HAS_VALUE> {
 
     /// Amount of ETH in wei to give the other contract.
     /// Note: adding value will prevent calls to non-payable methods.
-    pub fn value(self, value: U256) -> Context<S, true> {
-        Context {
-            value,
+    pub fn value(self, value: U256) -> Call<S, true> {
+        Call {
+            value: Some(value),
             gas: self.gas,
-            _storage: self._storage,
+            storage: self.storage,
         }
     }
 }
 
-impl<S, const HAS_VALUE: bool> CallContext for Context<S, HAS_VALUE> {
+impl<S, const HAS_VALUE: bool> CallContext for Call<S, HAS_VALUE> {
     fn gas(&self) -> u64 {
         self.gas
     }
 }
-
-impl StaticCallContext for Context<(), false> {}
-
-unsafe impl<S: TopLevelStorage, const HAS_VALUE: bool> MutatingCallContext
-    for Context<&mut S, HAS_VALUE>
-{
-    fn value(&self) -> U256 {
-        self.value
-    }
-}
-
-impl<S: TopLevelStorage> NonPayableCallContext for Context<&mut S, false> {}
 
 // allow &self to be a `pure` and `static` call context
 impl<'a, T> CallContext for &'a T
@@ -137,3 +159,33 @@ where
 }
 
 impl<T> NonPayableCallContext for &mut T where T: TopLevelStorage {}
+
+cfg_if! {
+    if #[cfg(all(feature = "storage-cache", feature = "reentrant"))] {
+        // The following impls safeguard state during reentrancy scenarios
+
+        impl<S: TopLevelStorage> StaticCallContext for Call<S, false> {}
+
+        impl<S: TopLevelStorage> NonPayableCallContext for Call<&mut S, false> {}
+
+        unsafe impl<S: TopLevelStorage, const HAS_VALUE: bool> MutatingCallContext
+            for Call<&mut S, HAS_VALUE>
+        {
+            fn value(&self) -> U256 {
+                self.value.unwrap_or_default()
+            }
+        }
+    } else {
+        // If there's no reentrancy, all calls are storage safe
+
+        impl<S> StaticCallContext for Call<S, false> {}
+
+        impl<S> NonPayableCallContext for Call<S, false> {}
+
+        unsafe impl<S, const HAS_VALUE: bool> MutatingCallContext for Call<S, HAS_VALUE> {
+            fn value(&self) -> U256 {
+                self.value.unwrap_or_default()
+            }
+        }
+    }
+}

--- a/stylus-sdk/src/call/mod.rs
+++ b/stylus-sdk/src/call/mod.rs
@@ -9,49 +9,33 @@
 //!
 //! Additional helpers exist for specific use-cases like [`transfer_eth`].
 
-use crate::storage::TopLevelStorage;
 use alloc::vec::Vec;
-use alloy_primitives::{Address, U256};
-use core::sync::atomic::{AtomicBool, Ordering};
+use alloy_primitives::Address;
 
-pub use self::{context::Context, error::Error, raw::RawCall, traits::*};
+pub use self::{context::Call, error::Error, raw::RawCall, traits::*, transfer::transfer_eth};
 
 pub(crate) use raw::CachePolicy;
 
-#[cfg(feature = "storage-cache")]
+#[cfg(all(feature = "storage-cache", feature = "reentrant"))]
 use crate::storage::Storage;
 
 mod context;
 mod error;
 mod raw;
 mod traits;
+mod transfer;
 
-/// Dangerous. Enables reentrancy.
-///
-/// # Safety
-///
-/// If a contract calls another that then calls the first, it is said to be reentrant.
-/// By default, all Stylus programs revert when this happened.
-/// This method overrides this behavior, allowing reentrant calls to proceed.
-///
-/// This is extremely dangerous, and should be done only after careful review --
-/// ideally by 3rd party auditors. Numerous exploits and hacks have in Web3 are
-/// attributable to developers misusing or not fully understanding reentrant patterns.
-///
-/// If enabled, the Stylus SDK will flush the storage cache in between reentrant calls,
-/// persisting values to state that might be used by inner calls. Note that preventing storage
-/// invalidation is only part of the battle in the fight against exploits.
-pub unsafe fn opt_into_reentrancy() {
-    ENABLE_REENTRANCY.store(true, Ordering::Relaxed)
+macro_rules! unsafe_reentrant {
+    ($block:block) => {
+        #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
+        unsafe {
+            $block
+        }
+
+        #[cfg(not(all(feature = "storage-cache", feature = "reentrant")))]
+        $block
+    };
 }
-
-/// Whether the program has opted into reentrancy.
-pub fn reentrancy_enabled() -> bool {
-    ENABLE_REENTRANCY.load(Ordering::Relaxed)
-}
-
-/// Whether the program has opted in to reentrancy.
-static ENABLE_REENTRANCY: AtomicBool = AtomicBool::new(false);
 
 /// Static calls the contract at the given address.
 pub fn static_call(
@@ -59,48 +43,47 @@ pub fn static_call(
     to: Address,
     data: &[u8],
 ) -> Result<Vec<u8>, Error> {
-    #[cfg(feature = "storage-cache")]
-    if reentrancy_enabled() {
-        // flush storage to persist changes, but don't invalidate the cache
-        Storage::flush();
-    }
-    unsafe {
+    #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
+    Storage::flush(); // flush storage to persist changes, but don't invalidate the cache
+
+    unsafe_reentrant! {{
         RawCall::new_static()
             .gas(context.gas())
             .call(to, data)
             .map_err(Error::Revert)
-    }
+    }}
+}
+
+/// Delegate calls the contract at the given address.
+///
+/// # Safety
+///
+/// A delegate call must trust the other contract to uphold safety requirements.
+/// Though this function clears any cached values, the other contract may arbitrarily change storage,
+/// spend ether, and do other things one should never blindly allow other contracts to do.
+pub unsafe fn delegate_call(
+    context: impl MutatingCallContext,
+    to: Address,
+    data: &[u8],
+) -> Result<Vec<u8>, Error> {
+    #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
+    Storage::clear(); // clear the storage to persist changes, invalidating the cache
+
+    RawCall::new_with_value(context.value())
+        .gas(context.gas())
+        .call(to, data)
+        .map_err(Error::Revert)
 }
 
 /// Calls the contract at the given address.
 pub fn call(context: impl MutatingCallContext, to: Address, data: &[u8]) -> Result<Vec<u8>, Error> {
-    #[cfg(feature = "storage-cache")]
-    if reentrancy_enabled() {
-        // clear the storage to persist changes, invalidating the cache
-        Storage::clear();
-    }
-    unsafe {
+    #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
+    Storage::clear(); // clear the storage to persist changes, invalidating the cache
+
+    unsafe_reentrant! {{
         RawCall::new_with_value(context.value())
             .gas(context.gas())
             .call(to, data)
             .map_err(Error::Revert)
-    }
-}
-
-/// Transfers an amount of ETH in wei to the given account.
-/// Note that this method will call the other contract, which may in turn call others.
-///
-/// All gas is supplied, which the recipient may burn.
-/// If this is not desired, the [`call`] method can be used directly.
-pub fn transfer_eth(
-    _storage: &mut impl TopLevelStorage,
-    to: Address,
-    amount: U256,
-) -> Result<(), Vec<u8>> {
-    unsafe {
-        RawCall::new_with_value(amount)
-            .skip_return_data()
-            .call(to, &[])?;
-    }
-    Ok(())
+    }}
 }

--- a/stylus-sdk/src/call/raw.rs
+++ b/stylus-sdk/src/call/raw.rs
@@ -91,7 +91,7 @@ impl RawCall {
     ///     let result = RawCall::new()       // configure a call
     ///         .gas(2100)                    // supply 2100 gas
     ///         .limit_return_data(0, 32)     // only read the first 32 bytes back
-    ///         .flush_storage_cache()        // flush the storage cache before the call
+    ///     //  .flush_storage_cache()        // flush the storage cache before the call (available in `reentrant`)
     ///         .call(contract, calldata);    // do the call
     /// }
     /// ```

--- a/stylus-sdk/src/call/raw.rs
+++ b/stylus-sdk/src/call/raw.rs
@@ -7,8 +7,20 @@ use crate::{
 };
 use alloy_primitives::{Address, B256, U256};
 
-#[cfg(feature = "storage-cache")]
+#[cfg(all(feature = "storage-cache", feature = "reentrant"))]
 use crate::storage::StorageCache;
+
+macro_rules! unsafe_reentrant {
+    ($(#[$meta:meta])* pub fn $name:ident $($rest:tt)*) => {
+        #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
+        $(#[$meta])*
+        pub unsafe fn $name $($rest)*
+
+        #[cfg(not(all(feature = "storage-cache", feature = "reentrant")))]
+        $(#[$meta])*
+        pub fn $name $($rest)*
+    };
+}
 
 /// Mechanism for performing raw calls to other contracts.
 ///
@@ -144,72 +156,75 @@ impl RawCall {
     }
 
     /// Write all cached values to persistent storage before the call.
-    #[cfg(feature = "storage-cache")]
+    #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
     pub fn flush_storage_cache(mut self) -> Self {
         self.cache_policy = self.cache_policy.max(CachePolicy::Flush);
         self
     }
 
     /// Flush and clear the storage cache before the call.
-    #[cfg(feature = "storage-cache")]
+    #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
     pub fn clear_storage_cache(mut self) -> Self {
         self.cache_policy = CachePolicy::Clear;
         self
     }
 
-    /// Performs a raw call to another contract at the given address with the given `calldata`.
-    ///
-    /// # Safety
-    ///
-    /// Enables storage aliasing if used in the middle of a storage reference's lifetime and reentrancy is allowed.
-    ///
-    /// For extra flexibility, this method does not clear the global storage cache.
-    /// See [`StorageCache::flush`] and [`StorageCache::clear`] for more information.
-    pub unsafe fn call(self, contract: Address, calldata: &[u8]) -> ArbResult {
-        let mut outs_len = 0;
-        let gas = self.gas.unwrap_or(u64::MAX); // will be clamped by 63/64 rule
-        let value = B256::from(self.callvalue);
-        let status = unsafe {
-            #[cfg(feature = "storage-cache")]
-            match self.cache_policy {
-                CachePolicy::Clear => StorageCache::clear(),
-                CachePolicy::Flush => StorageCache::flush(),
-                CachePolicy::DoNothing => {}
-            }
-            match self.kind {
-                CallKind::Basic => hostio::call_contract(
-                    contract.as_ptr(),
-                    calldata.as_ptr(),
-                    calldata.len(),
-                    value.as_ptr(),
-                    gas,
-                    &mut outs_len,
-                ),
-                CallKind::Delegate => hostio::delegate_call_contract(
-                    contract.as_ptr(),
-                    calldata.as_ptr(),
-                    calldata.len(),
-                    gas,
-                    &mut outs_len,
-                ),
-                CallKind::Static => hostio::static_call_contract(
-                    contract.as_ptr(),
-                    calldata.as_ptr(),
-                    calldata.len(),
-                    gas,
-                    &mut outs_len,
-                ),
-            }
-        };
+    unsafe_reentrant! {
+        /// Performs a raw call to another contract at the given address with the given `calldata`.
+        ///
+        /// # Safety
+        ///
+        /// This function becomes `unsafe` when the `reentrant` and `storage-cache` features are enabled.
+        /// That's because raw calls might alias storage if used in the middle of a storage ref's lifetime.
+        ///
+        /// For extra flexibility, this method does not clear the global storage cache by default.
+        /// See [`flush_storage_cache`] and [`clear_storage_cache`] for more information.
+        pub fn call(self, contract: Address, calldata: &[u8]) -> ArbResult {
+            let mut outs_len = 0;
+            let gas = self.gas.unwrap_or(u64::MAX); // will be clamped by 63/64 rule
+            let value = B256::from(self.callvalue);
+            let status = unsafe {
+                #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
+                match self.cache_policy {
+                    CachePolicy::Clear => StorageCache::clear(),
+                    CachePolicy::Flush => StorageCache::flush(),
+                    CachePolicy::DoNothing => {}
+                }
+                match self.kind {
+                    CallKind::Basic => hostio::call_contract(
+                        contract.as_ptr(),
+                        calldata.as_ptr(),
+                        calldata.len(),
+                        value.as_ptr(),
+                        gas,
+                        &mut outs_len,
+                    ),
+                    CallKind::Delegate => hostio::delegate_call_contract(
+                        contract.as_ptr(),
+                        calldata.as_ptr(),
+                        calldata.len(),
+                        gas,
+                        &mut outs_len,
+                    ),
+                    CallKind::Static => hostio::static_call_contract(
+                        contract.as_ptr(),
+                        calldata.as_ptr(),
+                        calldata.len(),
+                        gas,
+                        &mut outs_len,
+                    ),
+                }
+            };
 
-        unsafe {
-            RETURN_DATA_LEN.set(outs_len);
-        }
+            unsafe {
+                RETURN_DATA_LEN.set(outs_len);
+            }
 
-        let outs = read_return_data(self.offset, self.size);
-        match status {
-            0 => Ok(outs),
-            _ => Err(outs),
+            let outs = read_return_data(self.offset, self.size);
+            match status {
+                0 => Ok(outs),
+                _ => Err(outs),
+            }
         }
     }
 }

--- a/stylus-sdk/src/call/traits.rs
+++ b/stylus-sdk/src/call/traits.rs
@@ -33,11 +33,3 @@ pub unsafe trait MutatingCallContext: CallContext {
 ///
 /// Note: any implementations of this must return zero for [`MutatingCallContext::value`].
 pub trait NonPayableCallContext: MutatingCallContext {}
-
-impl CallContext for () {
-    fn gas(&self) -> u64 {
-        u64::MAX // use everything
-    }
-}
-
-impl StaticCallContext for () {}

--- a/stylus-sdk/src/call/transfer.rs
+++ b/stylus-sdk/src/call/transfer.rs
@@ -1,0 +1,45 @@
+// Copyright 2022-2023, Offchain Labs, Inc.
+// For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
+
+use crate::call::RawCall;
+use alloc::vec::Vec;
+use alloy_primitives::{Address, U256};
+
+#[cfg(all(feature = "storage-cache", feature = "reentrant"))]
+use crate::storage::TopLevelStorage;
+
+#[cfg(all(feature = "storage-cache", feature = "reentrant"))]
+use crate::storage::Storage;
+
+/// Transfers an amount of ETH in wei to the given account.
+/// Note that this method will call the other contract, which may in turn call others.
+///
+/// All gas is supplied, which the recipient may burn.
+/// If this is not desired, the [`call`] method can be used directly.
+#[cfg(all(feature = "storage-cache", feature = "reentrant"))]
+pub fn transfer_eth(
+    _storage: &mut impl TopLevelStorage,
+    to: Address,
+    amount: U256,
+) -> Result<(), Vec<u8>> {
+    Storage::clear(); // clear the storage to persist changes, invalidating the cache
+    unsafe {
+        RawCall::new_with_value(amount)
+            .skip_return_data()
+            .call(to, &[])?;
+    }
+    Ok(())
+}
+
+/// Transfers an amount of ETH in wei to the given account.
+/// Note that this method will call the other contract, which may in turn call others.
+///
+/// All gas is supplied, which the recipient may burn.
+/// If this is not desired, the [`call`] method can be used directly.
+#[cfg(not(all(feature = "storage-cache", feature = "reentrant")))]
+pub fn transfer_eth(to: Address, amount: U256) -> Result<(), Vec<u8>> {
+    RawCall::new_with_value(amount)
+        .skip_return_data()
+        .call(to, &[])?;
+    Ok(())
+}

--- a/stylus-sdk/src/call/transfer.rs
+++ b/stylus-sdk/src/call/transfer.rs
@@ -16,6 +16,8 @@ use crate::storage::Storage;
 ///
 /// All gas is supplied, which the recipient may burn.
 /// If this is not desired, the [`call`] method can be used directly.
+///
+/// [`call`]: super::call
 #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
 pub fn transfer_eth(
     _storage: &mut impl TopLevelStorage,

--- a/stylus-sdk/src/deploy/raw.rs
+++ b/stylus-sdk/src/deploy/raw.rs
@@ -9,7 +9,7 @@ use crate::{
 use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, U256};
 
-#[cfg(feature = "storage-cache")]
+#[cfg(all(feature = "storage-cache", feature = "reentrant"))]
 use crate::storage::StorageCache;
 
 /// Mechanism for performing raw deploys of other contracts.
@@ -87,7 +87,7 @@ impl RawDeploy {
     /// For extra flexibility, this method does not clear the global storage cache.
     /// See [`StorageCache::flush`] and [`StorageCache::clear`] for more information.
     pub unsafe fn deploy(self, code: &[u8], endowment: U256) -> Result<Address, Vec<u8>> {
-        #[cfg(feature = "storage-cache")]
+        #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
         match self.cache_policy {
             CachePolicy::Clear => StorageCache::clear(),
             CachePolicy::Flush => StorageCache::flush(),


### PR DESCRIPTION
Simplifies calls to other contracts by
- feature-gating all reentrancy behind the new `reentrant` flag
- a new `Call` type for making safe calls with doc examples

```rs
sol_interface! {
    interface IService {
        function makePayment(address user) payable returns (string);
    }
}

pub fn do_call(account: IService, user: Address) -> Result<String, Error> {
    let context = Call::new()
        .gas(evm::gas_left() / 2)        // limit to half the gas left
        .value(msg::value());            // set the callvalue

    account.make_payment(context, user)  // note the snake case
}
```
