### PR TITLE
feature: add for uint storageguards

### DIFF
--- a/stylus-sdk/src/storage/traits.rs
+++ b/stylus-sdk/src/storage/traits.rs
@@ -174,6 +174,20 @@ impl<'a, T: 'a> DerefMut for StorageGuardMut<'a, T> {
     }
 }
 
+impl<'a, const B: usize, const L: usize> core::ops::Add<Uint<B, L>>
+    for &'a mut StorageGuardMut<'a, super::StorageUint<B, L>>
+{
+    type Output = &'a mut StorageGuardMut<'a, super::StorageUint<B, L>>;
+
+    fn add(self, rhs: Uint<B, L>) -> Self::Output {
+        let pre = self.get();
+        let post = pre + rhs;
+        self.set(post);
+
+        self
+    }
+}
+
 /// Trait for managing access to persistent storage.
 /// Notable implementations include the [`StorageCache`](super::StorageCache)
 /// and [`EagerStorage`](super::EagerStorage) types.

--- a/stylus-sdk/src/storage/traits.rs
+++ b/stylus-sdk/src/storage/traits.rs
@@ -174,17 +174,13 @@ impl<'a, T: 'a> DerefMut for StorageGuardMut<'a, T> {
     }
 }
 
-impl<'a, const B: usize, const L: usize> core::ops::Add<Uint<B, L>>
-    for &'a mut StorageGuardMut<'a, super::StorageUint<B, L>>
+impl<'a, const B: usize, const L: usize> core::ops::AddAssign<Uint<B, L>>
+    for StorageGuardMut<'a, super::StorageUint<B, L>>
 {
-    type Output = &'a mut StorageGuardMut<'a, super::StorageUint<B, L>>;
-
-    fn add(self, rhs: Uint<B, L>) -> Self::Output {
+    fn add_assign(&mut self, rhs: Uint<B, L>) {
         let pre = self.get();
         let post = pre + rhs;
         self.set(post);
-
-        self
     }
 }
 


### PR DESCRIPTION
Adds an add implementation to `&mut MutStorageGuard` to allow for direct addition

Goal is to allow this in contracts

```

self.balance_mapping.setter(sender_address) += U256::from(10000);

```

This is untested.