### PR TITLE
Make `Call::new` a compile error in reentrant patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-proc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-sdk"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["stylus-sdk", "stylus-proc"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Offchain Labs"]
 license = "MIT OR Apache-2.0"
@@ -35,4 +35,4 @@ convert_case = "0.6.0"
 
 # members
 stylus-sdk = { path = "stylus-sdk" }
-stylus-proc = { path = "stylus-proc", version = "0.3.0" }
+stylus-proc = { path = "stylus-proc", version = "0.4.0" }

--- a/stylus-sdk/src/call/mod.rs
+++ b/stylus-sdk/src/call/mod.rs
@@ -4,10 +4,12 @@
 //! Call other contracts.
 //!
 //! There are two primary ways to make calls to other contracts via the Stylus SDK.
-//! - [`CallContext`] for richly-typed calls.
-//! - The `unsafe` [`RawCall`] for `unsafe`, bytes-in bytes-out calls.
+//! - [`Call`] with [`sol_interface!`][sol_interface] for richly-typed calls.
+//! - [`RawCall`] for `unsafe`, bytes-in bytes-out calls.
 //!
 //! Additional helpers exist for specific use-cases like [`transfer_eth`].
+//!
+//! [sol_interface]: crate::prelude::sol_interface
 
 use alloc::vec::Vec;
 use alloy_primitives::Address;

--- a/stylus-sdk/src/call/raw.rs
+++ b/stylus-sdk/src/call/raw.rs
@@ -78,7 +78,7 @@ impl Default for RustVec {
 }
 
 impl RawCall {
-    /// Begin configuring the raw call, similar to how [`std::fs::OpenOptions`] works.
+    /// Begin configuring the raw call, similar to how [`std::fs::OpenOptions`][OpenOptions] works.
     ///
     /// ```no_run
     /// use stylus_sdk::call::RawCall;
@@ -95,6 +95,8 @@ impl RawCall {
     ///         .call(contract, calldata);    // do the call
     /// }
     /// ```
+    ///
+    /// [OpenOptions]: https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html
     pub fn new() -> Self {
         Default::default()
     }

--- a/stylus-sdk/src/call/transfer.rs
+++ b/stylus-sdk/src/call/transfer.rs
@@ -15,7 +15,7 @@ use crate::storage::Storage;
 /// Note that this method will call the other contract, which may in turn call others.
 ///
 /// All gas is supplied, which the recipient may burn.
-/// If this is not desired, the [`call`] method can be used directly.
+/// If this is not desired, the [`call`](super::call) function may be used directly.
 ///
 /// [`call`]: super::call
 #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
@@ -37,7 +37,12 @@ pub fn transfer_eth(
 /// Note that this method will call the other contract, which may in turn call others.
 ///
 /// All gas is supplied, which the recipient may burn.
-/// If this is not desired, the [`call`] method can be used directly.
+/// If this is not desired, the [`call`](super::call) function may be used directly.
+///
+/// ```ignore
+/// transfer_eth(recipient, value)?;                 // these two are equivalent
+/// call(Call::new().value(value), recipient, &[])?; // these two are equivalent
+/// ```
 #[cfg(not(all(feature = "storage-cache", feature = "reentrant")))]
 pub fn transfer_eth(to: Address, amount: U256) -> Result<(), Vec<u8>> {
     RawCall::new_with_value(amount)

--- a/stylus-sdk/src/debug.rs
+++ b/stylus-sdk/src/debug.rs
@@ -6,6 +6,7 @@
 //! ```no_run
 //! use stylus_sdk::console;
 //! use stylus_sdk::alloy_primitives::address;
+//! extern crate alloc;
 //!
 //! let arbinaut = address!("361594F5429D23ECE0A88E4fBE529E1c49D524d8");
 //! console!("Gm {}", arbinaut); // prints nothing in production
@@ -23,7 +24,7 @@ pub fn console_log<T: AsRef<str>>(text: T) {
 #[macro_export]
 macro_rules! console {
     ($($msg:tt)*) => {
-        $crate::debug::console_log(format!($($msg)*));
+        $crate::debug::console_log(alloc::format!($($msg)*));
     };
 }
 

--- a/stylus-sdk/src/deploy/raw.rs
+++ b/stylus-sdk/src/deploy/raw.rs
@@ -85,7 +85,10 @@ impl RawDeploy {
     /// reference's lifetime and if reentrancy is allowed.
     ///
     /// For extra flexibility, this method does not clear the global storage cache.
-    /// See [`StorageCache::flush`] and [`StorageCache::clear`] for more information.
+    /// See [`StorageCache::flush`][flush] and [`StorageCache::clear`][clear] for more information.
+    ///
+    /// [flush]: crate::storage::StorageCache::flush
+    /// [clear]: crate::storage::StorageCache::clear
     pub unsafe fn deploy(self, code: &[u8], endowment: U256) -> Result<Address, Vec<u8>> {
         #[cfg(all(feature = "storage-cache", feature = "reentrant"))]
         match self.cache_policy {

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -114,7 +114,7 @@ impl<S: StorageType> StorageVec<S> {
         Some(store.load_mut())
     }
 
-    /// Like [`std::vec::Vec::push`], but returns a mutable accessor to the new slot.
+    /// Like [`std::vec::Vec::push`][vec_push], but returns a mutable accessor to the new slot.
     /// This enables pushing elements without constructing them first.
     ///
     /// # Example
@@ -131,6 +131,8 @@ impl<S: StorageType> StorageVec<S> {
     /// assert_eq!(value, U256::from(8));
     /// assert_eq!(inner_vec.len(), 1);
     /// ```
+    ///
+    /// [vec_push]: https://doc.rust-lang.org/std/vec/struct.Vec.html#method.push
     pub fn grow(&mut self) -> StorageGuardMut<S> {
         let index = self.len();
         unsafe { self.set_len(index + 1) };


### PR DESCRIPTION
Makes `Call::new` a compile error when used with the `reentrant` feature flag enabled. This is a sensible behavior given `new` is never correct in reentrant programming.

This is a minor but theoretically breaking change, so we'll bump the version number.

This PR makes other documentation improvements.