### PR TITLE
Configure selectors

### DIFF
--- a/stylus-proc/src/methods/external.rs
+++ b/stylus-proc/src/methods/external.rs
@@ -369,10 +369,14 @@ impl Parse for SelectorArgs {
                     id = Some(match lit {
                         Lit::Int(lit) => lit.base10_parse()?,
                         Lit::Str(lit) => {
-                            let hash = types::keccak(lit.value().as_bytes());
+                            let name = lit.value();
+                            if !name.contains('(') {
+                                error!(@lit, "missing parens. Perhaps you meant name = \"{}\"?", name);
+                            }
+                            let hash = types::keccak(name.as_bytes());
                             u32::from_be_bytes(hash[..4].try_into().unwrap())
                         }
-                        _ => error!(@lit, "Expected u32 or string"),
+                        _ => error!(@lit, "expected u32 or string"),
                     });
                 }
                 "name" => {

--- a/stylus-proc/src/methods/external.rs
+++ b/stylus-proc/src/methods/external.rs
@@ -353,7 +353,7 @@ impl Parse for SelectorArgs {
         let input = content;
 
         if input.is_empty() {
-            error!(@input.span(), "mising id or text argument");
+            error!(@input.span(), "missing id or text argument");
         }
 
         while !input.is_empty() {

--- a/stylus-proc/src/types.rs
+++ b/stylus-proc/src/types.rs
@@ -2,6 +2,7 @@
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
 use alloy_sol_types::SolType;
+use sha3::{Digest, Keccak256};
 use std::{borrow::Cow, fmt::Display, num::NonZeroU16, str::FromStr};
 use syn::Token;
 use syn_solidity::Type;
@@ -123,4 +124,10 @@ pub fn solidity_type_info(ty: &Type) -> (Cow<'static, str>, Cow<'static, str>) {
         }
         _ => todo!("Solidity type {ty} is not yet implemented in sol_interface!"),
     }
+}
+
+pub fn keccak<T: AsRef<[u8]>>(preimage: T) -> [u8; 32] {
+    let mut hasher = Keccak256::new();
+    hasher.update(preimage);
+    hasher.finalize().into()
 }


### PR DESCRIPTION
This PR introduces configuration options for method selectors via the new `#[selector]` attribute.

```rs
impl Contract {
    #[selector(name = "otherName")]
    pub fn renamed() {
        ...
    }
    
    #[selector(id = "otherFunc(uint64)")]
    pub fn other_selector(value: U64) {
        ...
    }
    
    #[selector(id = 0xba5eba11)]
    pub fn exact_selector() {
        ...
    }
```

```sh
$ cargo stylus export-abi
```

```solidity
/**
 * This file was automatically generated by Stylus and represents a Rust program.
 * For more information, please see [The Stylus SDK](https://github.com/OffchainLabs/stylus-sdk-rs).
 */
 
interface IContract {
        function otherName() external pure;

        // note: selector was overridden to be 0x7cc01843.
        function otherSelector(uint64 value) external pure;

        // note: selector was overridden to be 0xba5eba11.
        function exactSelector() external pure;
}
```