### PR TITLE
Fix codehash for EOA's and `FixedBytes` in `sol_interface!`

### DIFF
--- a/stylus-proc/src/types.rs
+++ b/stylus-proc/src/types.rs
@@ -82,7 +82,7 @@ pub fn solidity_type_info(ty: &Type) -> (Cow<'static, str>, Cow<'static, str>) {
         Type::String(_) => simple!(String),
         Type::Bytes(_) => simple!(Bytes),
         Type::FixedBytes(_, size) => (
-            "stylus_sdk::abi::FixedBytesSolType<{size}>".into(),
+            format!("stylus_sdk::abi::FixedBytesSolType<{size}>").into(),
             abi!("bytes[{size}]"),
         ),
         Type::Uint(_, size) => {


### PR DESCRIPTION
Fixes some minor edge cases in the SDK

Included is the new `Address::is_eoa` method for detecting if an account is an Externally Owned Account
```rs
let arbinaut = address!(361594F5429D23ECE0A88E4fBE529E1c49D524d8);
assert!(arbinaut.is_eoa());
assert!(!contract::address().is_eoa())
```