### PR TITLE
Rename `is_eoa` to `has_code`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-proc"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -451,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-sdk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["stylus-sdk", "stylus-proc"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Offchain Labs"]
 license = "MIT OR Apache-2.0"

--- a/stylus-sdk/src/types.rs
+++ b/stylus-sdk/src/types.rs
@@ -26,10 +26,12 @@ pub trait AddressVM {
     /// [`EOA`]: https://ethereum.org/en/developers/docs/accounts/#types-of-account
     fn codehash(&self) -> B256;
 
-    /// Determines if an account is an [`EOA`].
+    /// Determines if an account has code. Note that this is insufficient to determine if an address is an
+    /// [`EOA`]. During contract deployment, an account only gets its code at the very end, meaning that
+    /// this method will return `false` up until that point.
     ///
     /// [`EOA`]: https://ethereum.org/en/developers/docs/accounts/#types-of-account
-    fn is_eoa(&self) -> bool;
+    fn has_code(&self) -> bool;
 }
 
 impl AddressVM for Address {
@@ -45,7 +47,7 @@ impl AddressVM for Address {
         data.into()
     }
 
-    fn is_eoa(&self) -> bool {
+    fn has_code(&self) -> bool {
         let hash = self.codehash();
         hash.is_zero()
             || hash == b256!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")

--- a/stylus-sdk/src/types.rs
+++ b/stylus-sdk/src/types.rs
@@ -28,7 +28,7 @@ pub trait AddressVM {
 
     /// Determines if an account has code. Note that this is insufficient to determine if an address is an
     /// [`EOA`]. During contract deployment, an account only gets its code at the very end, meaning that
-    /// this method will return `false` up until that point.
+    /// this method will return `false` while the constructor is executing.
     ///
     /// [`EOA`]: https://ethereum.org/en/developers/docs/accounts/#types-of-account
     fn has_code(&self) -> bool;


### PR DESCRIPTION
This PR renames `is_eoa` to `has_code` for clarity around the constructor edge case in which the method will return false.