### PR TITLE
remove mut from StorageString::get_string

### DIFF
--- a/stylus-sdk/src/storage/bytes.rs
+++ b/stylus-sdk/src/storage/bytes.rs
@@ -300,7 +300,7 @@ impl StorageString {
     }
 
     /// Gets the underlying [`String`], ignoring any invalid data.
-    pub fn get_string(&mut self) -> String {
+    pub fn get_string(&self) -> String {
         let bytes = self.0.get_bytes();
         String::from_utf8_lossy(&bytes).into()
     }


### PR DESCRIPTION
## Description

Remove `mut` from `StorageString::get_string`

## Checklist

- [X] I have documented these changes where necessary.
- [X] I have read the [DCO][DCO] and ensured that these changes comply.
- [X] I assign this work under its [open source licensing][terms].

[DCO]: licenses/DCO.txt
[terms]: licenses/COPYRIGHT.md
