### PR TITLE
Export main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,4 +35,4 @@ convert_case = "0.6.0"
 
 # members
 stylus-sdk = { path = "stylus-sdk" }
-stylus-proc = { path = "stylus-proc", version = "0.4.0" }
+stylus-proc = { path = "stylus-proc", version = "0.4.1" }

--- a/stylus-proc/src/methods/entrypoint.rs
+++ b/stylus-proc/src/methods/entrypoint.rs
@@ -47,7 +47,7 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 
             if cfg!(feature = "export-abi") {
                 output.extend(quote! {
-                    fn main() {
+                    pub fn main() {
                         stylus_sdk::abi::export::print_abi::<#name>();
                     }
                 });


### PR DESCRIPTION
Exports `main` in case the `entrypoint` macro is used in `lib.rs` :)