### PR TITLE
Fix Address has_code check

### DIFF
--- a/stylus-sdk/src/types.rs
+++ b/stylus-sdk/src/types.rs
@@ -49,7 +49,7 @@ impl AddressVM for Address {
 
     fn has_code(&self) -> bool {
         let hash = self.codehash();
-        hash.is_zero()
+        !hash.is_zero()
             || hash == b256!("c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470")
     }
 }


### PR DESCRIPTION
## Description

To check if an address has code, we have to check that the codehash is not zero

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: licenses/DCO.txt
[terms]: licenses/COPYRIGHT.md
