### PR TITLE
Set Sepolia Priv Key as CI Env Var

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -14,6 +14,7 @@ jobs:
     name: 'Test (Smoke)(${{ matrix.cfg_release_channel }})'
     env:
       CFG_RELEASE_CHANNEL: ${{ matrix.cfg_release_channel }}
+      PRIV_KEY: ${{ secrets.SEPOLIA_PRIVATE_KEY }}
     strategy:
       matrix:
         target: [wasm32-unknown-unknown]

--- a/ci/smoke_test.sh
+++ b/ci/smoke_test.sh
@@ -11,4 +11,4 @@ cargo stylus new counter
 cd counter
 echo "[workspace]" >> Cargo.toml
 
-cargo stylus deploy -e http://localhost:8547 --private-key 0xb6b15c8cb491557369f3c7d2c287b053eb229daa9c22138887752191c9520659
+cargo stylus deploy -e http://localhost:8547 --private-key $PRIV_KEY

--- a/ci/smoke_test.sh
+++ b/ci/smoke_test.sh
@@ -11,4 +11,4 @@ cargo stylus new counter
 cd counter
 echo "[workspace]" >> Cargo.toml
 
-cargo stylus deploy -e http://localhost:8547 --private-key $PRIV_KEY
+cargo stylus deploy --private-key $PRIV_KEY


### PR DESCRIPTION
This PR sets the sepolia private key used for smoke tests as a CI env var using a repository secret instead of hardcoding one