### PR TITLE
TopLevelStorage dependency injection

### DIFF
--- a/examples/erc20/src/erc20.rs
+++ b/examples/erc20/src/erc20.rs
@@ -14,7 +14,7 @@ use alloy_sol_types::sol;
 use core::marker::PhantomData;
 use stylus_sdk::{evm, msg, prelude::*};
 
-pub trait Erc20Params {
+pub trait Erc20Params: 'static {
     /// Immutable token name
     const NAME: &'static str;
 
@@ -27,7 +27,7 @@ pub trait Erc20Params {
 
 sol_storage! {
     /// Erc20 implements all ERC-20 methods.
-    pub struct Erc20<T> {
+    pub struct Erc20<T: Erc20Params> {
         /// Maps users to balances
         mapping(address => uint256) balances;
         /// Maps users to a mapping of each spender's allowance

--- a/stylus-proc/src/methods/entrypoint.rs
+++ b/stylus-proc/src/methods/entrypoint.rs
@@ -22,18 +22,7 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
             let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
             output.extend(quote!{
-                unsafe impl #impl_generics stylus_sdk::storage::TopLevelStorage for #name #ty_generics #where_clause {
-                    fn get_storage<S: 'static>(&mut self) -> &mut S {
-                        use stylus_sdk::storage::InnerStorage;
-                        unsafe { 
-                            self.try_get_storage().unwrap_or_else(|| {
-                                panic!(
-                                    "storage for type doesn't exist - type name is {}",
-                                    core::any::type_name::<S>()
-                                )}) 
-                        }
-                    }
-                }
+                unsafe impl #impl_generics stylus_sdk::storage::TopLevelStorage for #name #ty_generics #where_clause {}
 
                 fn entrypoint(input: alloc::vec::Vec<u8>) -> stylus_sdk::ArbResult {
                     use stylus_sdk::{abi::Router, alloy_primitives::U256, console, hex, storage::StorageType};

--- a/stylus-proc/src/methods/entrypoint.rs
+++ b/stylus-proc/src/methods/entrypoint.rs
@@ -22,7 +22,18 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
             let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
             output.extend(quote!{
-                unsafe impl #impl_generics stylus_sdk::storage::TopLevelStorage for #name #ty_generics #where_clause {}
+                unsafe impl #impl_generics stylus_sdk::storage::TopLevelStorage for #name #ty_generics #where_clause {
+                    fn get_storage<S: 'static>(&mut self) -> &mut S {
+                        use stylus_sdk::storage::InnerStorage;
+                        unsafe { 
+                            self.try_get_storage().unwrap_or_else(|| {
+                                panic!(
+                                    "storage for type doesn't exist - type name is {}",
+                                    core::any::type_name::<S>()
+                                )}) 
+                        }
+                    }
+                }
 
                 fn entrypoint(input: alloc::vec::Vec<u8>) -> stylus_sdk::ArbResult {
                     use stylus_sdk::{abi::Router, alloy_primitives::U256, console, hex, storage::StorageType};

--- a/stylus-proc/src/methods/external.rs
+++ b/stylus-proc/src/methods/external.rs
@@ -123,7 +123,7 @@ pub fn external(_attr: TokenStream, input: TokenStream) -> TokenStream {
         let storage = if needed_purity == Pure {
             quote!()
         } else if has_self {
-            quote! { core::borrow::BorrowMut::borrow_mut(storage), }
+            quote! { storage.inner_mut(), }
         } else {
             quote! { storage, }
         };
@@ -241,13 +241,6 @@ pub fn external(_attr: TokenStream, input: TokenStream) -> TokenStream {
         }
     });
 
-    // ensure we can actually borrow the things we inherit
-    let borrow_clauses = inherits.iter().map(|ty| {
-        quote! {
-            S: core::borrow::BorrowMut<#ty>
-        }
-    });
-
     let self_ty = &input.self_ty;
     let generic_params = &input.generics.params;
     let where_clauses = input
@@ -263,13 +256,9 @@ pub fn external(_attr: TokenStream, input: TokenStream) -> TokenStream {
 
         impl<S, #generic_params> stylus_sdk::abi::Router<S> for #self_ty
         where
-            S: stylus_sdk::storage::TopLevelStorage + core::borrow::BorrowMut<Self>,
-            #(#borrow_clauses,)*
+            S: stylus_sdk::storage::TopLevelStorage,
             #where_clauses
         {
-            // TODO: this should be configurable
-            type Storage = Self;
-
             #[inline(always)]
             fn route(storage: &mut S, selector: u32, input: &[u8]) -> Option<stylus_sdk::ArbResult> {
                 use stylus_sdk::{function_selector, alloy_sol_types::SolType};

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -41,11 +41,8 @@ pub mod internal;
 /// Composition with other routers is possible via `#[inherit]`.
 pub trait Router<S>
 where
-    S: TopLevelStorage + BorrowMut<Self::Storage>,
+    S: TopLevelStorage
 {
-    /// The type the [`TopLevelStorage`] borrows into. Usually just `Self`.
-    type Storage;
-
     /// Tries to find and execute a method for the given selector, returning `None` if none is found.
     /// Routes add via `#[inherit]` will only execute if no match is found among `Self`.
     /// This means that it is possible to override a method by redefining it in `Self`.

--- a/stylus-sdk/src/storage/array.rs
+++ b/stylus-sdk/src/storage/array.rs
@@ -1,7 +1,7 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
-use super::{Erase, StorageGuard, StorageGuardMut, StorageType};
+use super::{Erase, StorageGuard, StorageGuardMut, StorageLevel, StorageType};
 use alloy_primitives::U256;
 use core::marker::PhantomData;
 
@@ -10,6 +10,8 @@ pub struct StorageArray<S: StorageType, const N: usize> {
     slot: U256,
     marker: PhantomData<S>,
 }
+
+unsafe impl<S: StorageType, const N: usize> StorageLevel for StorageArray<S, N> {}
 
 impl<S: StorageType, const N: usize> StorageType for StorageArray<S, N> {
     type Wraps<'a> = StorageGuard<'a, StorageArray<S, N>> where Self: 'a;

--- a/stylus-sdk/src/storage/bytes.rs
+++ b/stylus-sdk/src/storage/bytes.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
-use super::{Erase, GlobalStorage, Storage, StorageB8, StorageGuard, StorageGuardMut, StorageType};
+use super::{Erase, GlobalStorage, Storage, StorageArray, StorageB8, StorageGuard, StorageGuardMut, StorageLevel, StorageType};
 use crate::crypto;
 use alloc::{
     string::{String, ToString},
@@ -15,6 +15,8 @@ pub struct StorageBytes {
     root: U256,
     base: OnceCell<U256>,
 }
+
+unsafe impl StorageLevel for StorageBytes {}
 
 impl StorageType for StorageBytes {
     type Wraps<'a> = StorageGuard<'a, StorageBytes> where Self: 'a;
@@ -263,6 +265,8 @@ impl<'a> Extend<&'a u8> for StorageBytes {
 
 /// Accessor for storage-backed bytes
 pub struct StorageString(pub StorageBytes);
+
+unsafe impl StorageLevel for StorageString {}
 
 impl StorageType for StorageString {
     type Wraps<'a> = StorageGuard<'a, StorageString> where Self: 'a;

--- a/stylus-sdk/src/storage/map.rs
+++ b/stylus-sdk/src/storage/map.rs
@@ -3,7 +3,7 @@
 
 use crate::crypto;
 
-use super::{Erase, SimpleStorageType, StorageGuard, StorageGuardMut, StorageType};
+use super::{Erase, SimpleStorageType, StorageBytes, StorageGuard, StorageGuardMut, StorageLevel, StorageType};
 use alloc::{string::String, vec::Vec};
 use alloy_primitives::{Address, FixedBytes, Signed, Uint, B256, U160, U256};
 use core::marker::PhantomData;
@@ -13,6 +13,8 @@ pub struct StorageMap<K: StorageKey, V: StorageType> {
     slot: U256,
     marker: PhantomData<(K, V)>,
 }
+
+unsafe impl<K: StorageKey, S: StorageType> StorageLevel for StorageMap<K, S> {}
 
 impl<K, V> StorageType for StorageMap<K, V>
 where

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -32,7 +32,7 @@ pub use bytes::{StorageBytes, StorageString};
 pub use map::{StorageKey, StorageMap};
 pub use traits::{
     Erase, GlobalStorage, SimpleStorageType, StorageGuard, StorageGuardMut, StorageType,
-    TopLevelStorage, InnerStorage,
+    TopLevelStorage, StorageLevel,
 };
 pub use vec::StorageVec;
 
@@ -160,6 +160,8 @@ impl<const B: usize, const L: usize> StorageUint<B, L> {
     }
 }
 
+unsafe impl<const B: usize, const L: usize> StorageLevel for StorageUint<B, L> {}
+
 impl<const B: usize, const L: usize> StorageType for StorageUint<B, L> {
     type Wraps<'a> = Uint<B, L>;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
@@ -235,6 +237,8 @@ impl<const B: usize, const L: usize> StorageSigned<B, L> {
     }
 }
 
+unsafe impl<const B: usize, const L: usize> StorageLevel for StorageSigned<B, L> {}
+
 impl<const B: usize, const L: usize> StorageType for StorageSigned<B, L> {
     type Wraps<'a> = Signed<B, L>;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
@@ -305,6 +309,8 @@ impl<const N: usize> StorageFixedBytes<N> {
         unsafe { Storage::set(self.slot, self.offset.into(), value) }
     }
 }
+
+unsafe impl<const N: usize> StorageLevel for StorageFixedBytes<N> {}
 
 impl<const N: usize> StorageType for StorageFixedBytes<N>
 where
@@ -386,6 +392,8 @@ impl StorageBool {
     }
 }
 
+unsafe impl StorageLevel for StorageBool {}
+
 impl StorageType for StorageBool {
     type Wraps<'a> = bool;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
@@ -459,6 +467,8 @@ impl StorageAddress {
     }
 }
 
+unsafe impl StorageLevel for StorageAddress {}
+
 impl StorageType for StorageAddress {
     type Wraps<'a> = Address;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
@@ -530,6 +540,8 @@ impl StorageBlockNumber {
         unsafe { Storage::set::<8>(self.slot, self.offset.into(), value) };
     }
 }
+
+unsafe impl StorageLevel for StorageBlockNumber {}
 
 impl StorageType for StorageBlockNumber {
     type Wraps<'a> = BlockNumber;
@@ -603,6 +615,8 @@ impl StorageBlockHash {
     }
 }
 
+unsafe impl StorageLevel for StorageBlockHash {}
+
 impl StorageType for StorageBlockHash {
     type Wraps<'a> = BlockHash;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
@@ -646,6 +660,8 @@ impl From<StorageBlockHash> for BlockHash {
         *value
     }
 }
+
+unsafe impl<T> StorageLevel for PhantomData<T> {}
 
 /// We implement `StorageType` for `PhantomData` so that storage types can be generic.
 impl<T> StorageType for PhantomData<T> {

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -32,7 +32,7 @@ pub use bytes::{StorageBytes, StorageString};
 pub use map::{StorageKey, StorageMap};
 pub use traits::{
     Erase, GlobalStorage, SimpleStorageType, StorageGuard, StorageGuardMut, StorageType,
-    TopLevelStorage,
+    TopLevelStorage, InnerStorage,
 };
 pub use vec::StorageVec;
 

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -160,8 +160,6 @@ impl<const B: usize, const L: usize> StorageUint<B, L> {
     }
 }
 
-unsafe impl<const B: usize, const L: usize> StorageLevel for StorageUint<B, L> {}
-
 impl<const B: usize, const L: usize> StorageType for StorageUint<B, L> {
     type Wraps<'a> = Uint<B, L>;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
@@ -237,8 +235,6 @@ impl<const B: usize, const L: usize> StorageSigned<B, L> {
     }
 }
 
-unsafe impl<const B: usize, const L: usize> StorageLevel for StorageSigned<B, L> {}
-
 impl<const B: usize, const L: usize> StorageType for StorageSigned<B, L> {
     type Wraps<'a> = Signed<B, L>;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
@@ -309,8 +305,6 @@ impl<const N: usize> StorageFixedBytes<N> {
         unsafe { Storage::set(self.slot, self.offset.into(), value) }
     }
 }
-
-unsafe impl<const N: usize> StorageLevel for StorageFixedBytes<N> {}
 
 impl<const N: usize> StorageType for StorageFixedBytes<N>
 where
@@ -392,8 +386,6 @@ impl StorageBool {
     }
 }
 
-unsafe impl StorageLevel for StorageBool {}
-
 impl StorageType for StorageBool {
     type Wraps<'a> = bool;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
@@ -467,8 +459,6 @@ impl StorageAddress {
     }
 }
 
-unsafe impl StorageLevel for StorageAddress {}
-
 impl StorageType for StorageAddress {
     type Wraps<'a> = Address;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
@@ -541,8 +531,6 @@ impl StorageBlockNumber {
     }
 }
 
-unsafe impl StorageLevel for StorageBlockNumber {}
-
 impl StorageType for StorageBlockNumber {
     type Wraps<'a> = BlockNumber;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
@@ -614,8 +602,6 @@ impl StorageBlockHash {
         unsafe { Storage::set_word(self.slot, value) }
     }
 }
-
-unsafe impl StorageLevel for StorageBlockHash {}
 
 impl StorageType for StorageBlockHash {
     type Wraps<'a> = BlockHash;

--- a/stylus-sdk/src/storage/traits.rs
+++ b/stylus-sdk/src/storage/traits.rs
@@ -96,9 +96,17 @@ where
 ///
 /// The type must be top-level to prevent storage aliasing.
 pub unsafe trait TopLevelStorage {
-    fn get_storage<T: 'static>(&mut self) -> &mut T {
-        panic!("arbitrary storage access is not implemented",)
+
+    /// Retrieve mutable reference to inner storage of type [`S`]
+    fn get_storage<S: 'static>(&mut self) -> &mut S {
+        panic!("arbitrary storage access is not implemented")
     }
+}
+
+pub unsafe trait InnerStorage {
+
+    /// Try etrieve mutable reference to inner storage of type [`S`]
+    unsafe fn try_get_storage<S: 'static>(&mut self) -> Option<&mut S>;
 }
 
 /// Binds a storage accessor to a lifetime to prevent aliasing.

--- a/stylus-sdk/src/storage/traits.rs
+++ b/stylus-sdk/src/storage/traits.rs
@@ -95,7 +95,11 @@ where
 /// # Safety
 ///
 /// The type must be top-level to prevent storage aliasing.
-pub unsafe trait TopLevelStorage {}
+pub unsafe trait TopLevelStorage {
+    fn get_storage<T: 'static>(&mut self) -> &mut T {
+        panic!("arbitrary storage access is not implemented",)
+    }
+}
 
 /// Binds a storage accessor to a lifetime to prevent aliasing.
 /// Because this type doesn't implement `DerefMut`, mutable methods on the accessor aren't available.

--- a/stylus-sdk/src/storage/traits.rs
+++ b/stylus-sdk/src/storage/traits.rs
@@ -151,6 +151,8 @@ pub unsafe trait StorageLevel {
     }
 }
 
+unsafe impl<'a, T: SimpleStorageType<'a>> StorageLevel for T {}
+
 /// Binds a storage accessor to a lifetime to prevent aliasing.
 /// Because this type doesn't implement `DerefMut`, mutable methods on the accessor aren't available.
 /// For a mutable accessor, see [`StorageGuardMut`].

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -1,9 +1,7 @@
 // Copyright 2023, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
 
-use super::{
-    Erase, GlobalStorage, SimpleStorageType, Storage, StorageGuard, StorageGuardMut, StorageType,
-};
+use super::{Erase, GlobalStorage, SimpleStorageType, Storage, StorageGuard, StorageGuardMut, StorageKey, StorageLevel, StorageMap, StorageType};
 use crate::crypto;
 use alloy_primitives::U256;
 use core::{cell::OnceCell, marker::PhantomData};
@@ -14,6 +12,8 @@ pub struct StorageVec<S: StorageType> {
     base: OnceCell<U256>,
     marker: PhantomData<S>,
 }
+
+unsafe impl<S: StorageType> StorageLevel for StorageVec<S> {}
 
 impl<S: StorageType> StorageType for StorageVec<S> {
     type Wraps<'a> = StorageGuard<'a, StorageVec<S>> where Self: 'a;


### PR DESCRIPTION
## Description

### High Level
- fixes multi level inheritance (like 3 or more level of contract inheritance).
- allows to remove `#[borrow]` attributes tottaly (currently borrow attributes left for compatibility reason).
- lets to retrieve mutable and immutable references to a contract laying beneath struct that implements `TopLevelStorage`.
- can fix #107 and help to #106

### Low Level
- `TopLevelStorage` got two additional functions to retrieve inner laying type of contract by generic param `<S>`.
<img width="433" alt="image" src="https://github.com/OffchainLabs/stylus-sdk-rs/assets/37006439/ab66bb56-cd64-4f96-bbb1-79d1f5502e13">

- A new trait `StorageLevel` exposes two similar functions that just returns optional reference to the type `<S>`.
<img width="576" alt="image" src="https://github.com/OffchainLabs/stylus-sdk-rs/assets/37006439/840c5c26-8109-4064-8ff9-3cde248270cb">

- `StorageLevel` implemented by every type that can exist in contract storage same as `StorageType`. Simple storage types implementation returns just `None` since we're not expecting them to store inherited contract.
- Contracts implement `StorageLevel` within `solidity_storage` macro. Implementation checks that type of self is `T` if so reference will be returned (unsafe reference cast). Since every storage type implements `StorageLevel` trait then we can call same functions in every field recursively.
- We can remove `BorrowMut` constraint from the router trait and use our newly created functions to retrieve references to inner contracts. [This example](https://github.com/qalisander/stylus-multilevel-inheritance/blob/master/src/lib.rs) with inheritance of three is working now.
- `#[borrow]` attributes will generate `Borrow` and `BorrowMut` bindings still but basically there is no need in them.

### Compatibility
- generically typed contracts should have generics restricted by `'static` lifetime. ([example](https://github.com/qalisander/stylus-sdk-rs/blob/22d1c22990a43538e15742b3a4a294400122c441/examples/erc20/src/erc20.rs#L10))

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
