### PR TITLE
Use ABI Decode Params in Internal Call Return Data Parsing

### DIFF
--- a/stylus-proc/src/calls/mod.rs
+++ b/stylus-proc/src/calls/mod.rs
@@ -146,7 +146,7 @@ pub fn sol_interface(input: TokenStream) -> TokenStream {
                     let mut calldata = vec![#selector0, #selector1, #selector2, #selector3];
                     calldata.extend(args);
                     let returned = #call(context, self.address, &calldata)?;
-                    Ok(<(#return_type,) as #sol_type>::abi_decode(&returned, true)?.0)
+                    Ok(<(#return_type,) as #sol_type>::abi_decode_params(&returned, true)?.0)
                 }
             });
         }


### PR DESCRIPTION
We missed another spot where we have to use abi_decode_params with Alloy, leading to execution reverts when attempting to make external calls that return strings or bytes