### PR TITLE
feature: add support to convert from alloy_primitives::Bytes to stylus_sdk::Bytes

### DIFF
--- a/stylus-sdk/src/abi/bytes.rs
+++ b/stylus-sdk/src/abi/bytes.rs
@@ -27,6 +27,12 @@ impl From<Vec<u8>> for Bytes {
     }
 }
 
+impl From<alloy_primitives::Bytes> for Bytes {
+    fn from(value: alloy_primitives::Bytes) -> Self {
+        Self(value.to_vec())
+    }
+}
+
 impl Deref for Bytes {
     type Target = Vec<u8>;
 


### PR DESCRIPTION
## Description

This pr add the support for converting `alloy_primitives::Bytes` to `stylus_sdk::Bytes` so user can easily handle some bytes-type values returned from alloy to what we support.
