### PR TITLE
feat: possibility to reuse errors under SolidityError macro

### DIFF
--- a/stylus-proc/src/methods/error.rs
+++ b/stylus-proc/src/methods/error.rs
@@ -39,6 +39,14 @@ pub fn derive_solidity_error(input: TokenStream) -> TokenStream {
             }
         }
     });
+    
+    output.extend(quote! {
+        impl stylus_sdk::call::MethodError for #name {
+            fn encode(self) -> alloc::vec::Vec<u8> {
+                self.into()
+            }
+        }
+    });
 
     if cfg!(feature = "export-abi") {
         output.extend(quote! {


### PR DESCRIPTION
## Description

Adds implementation of `stylus_sdk::call::MethodError` trait inside SolidityError macro.

Resolves #135

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
