### PR TITLE
Simple derive macro for better struct support

### DIFF
--- a/stylus-proc/src/abi.rs
+++ b/stylus-proc/src/abi.rs
@@ -1,0 +1,18 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemStruct};
+
+pub fn derive_abi_type(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ItemStruct);
+    let name = &input.ident;
+    let name_str = name.to_string();
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics stylus_sdk::abi::AbiType for #name #ty_generics #where_clause {
+            type SolType = Self;
+            const ABI: stylus_sdk::abi::ConstString = stylus_sdk::abi::ConstString::new(#name_str);
+        }
+    }
+    .into()
+}

--- a/stylus-proc/src/lib.rs
+++ b/stylus-proc/src/lib.rs
@@ -30,6 +30,7 @@ macro_rules! error {
     }};
 }
 
+mod abi;
 mod calls;
 mod methods;
 mod storage;
@@ -540,4 +541,21 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 #[proc_macro_attribute]
 pub fn external(attr: TokenStream, input: TokenStream) -> TokenStream {
     methods::external::external(attr, input)
+}
+
+/// Implements the AbiType for arbitrary structs, allowing them to be used in external method
+/// return types and parameters. This derive is intended to be used within the
+/// [alloy_sol_types::sol] macro.
+///
+/// ```ignore
+/// sol! {
+///     #[derive(AbiType)]
+///     pub struct Foo {
+///         u256 bar;
+///     }
+/// }
+/// ```
+#[proc_macro_derive(AbiType)]
+pub fn derive_abi_type(input: TokenStream) -> TokenStream {
+    abi::derive_abi_type(input)
 }


### PR DESCRIPTION
## Description

This allows usage of `#[derive(AbiType)]` within the `sol! {}` macro to support structs as return types. This should also apply to usage as parameters. I am curious about other use-cases such as structs defined outside of the `sol! {}` macro, and structs define in the `sol_storage! {}` macro.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
