### PR TITLE
Allow struct references within sol_interface macro

### DIFF
--- a/stylus-proc/src/lib.rs
+++ b/stylus-proc/src/lib.rs
@@ -145,6 +145,10 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
 /// Observe the casing change. [`sol_interface!`] computes the selector based on the exact name passed in,
 /// which should almost always be `CamelCase`. For aesthetics, the rust functions will instead use `snake_case`.
 ///
+/// Note that structs may be used, as return types for example. Trying to reference structs using
+/// the Solidity path separator (`module.MyStruct`) is not currently supported and will fail at
+/// build-time.
+///
 /// # Reentrant calls
 ///
 /// Contracts that opt into reentrancy via the `reentrant` feature flag require extra care.

--- a/stylus-proc/src/types.rs
+++ b/stylus-proc/src/types.rs
@@ -122,6 +122,10 @@ pub fn solidity_type_info(ty: &Type) -> (Cow<'static, str>, Cow<'static, str>) {
                 (path.into(), abi.into())
             }
         }
+        Type::Custom(path) => {
+            let path: Cow<'static, str> = path.to_string().into();
+            (path.clone(), path)
+        }
         _ => todo!("Solidity type {ty} is not yet implemented in sol_interface!"),
     }
 }


### PR DESCRIPTION
fixes #74

## Description

Allows references to structs within the `sol_interface!` macro. 

~Would like to consider what to do for paths containing the dot separator in solidity before merging.~
Path with separator will be unsupported for now. Added to docstring for clarity.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
