### PR TITLE
Fail to build on duplicate selectors

### DIFF
--- a/stylus-proc/src/methods/external.rs
+++ b/stylus-proc/src/methods/external.rs
@@ -271,6 +271,7 @@ pub fn external(_attr: TokenStream, input: TokenStream) -> TokenStream {
             type Storage = Self;
 
             #[inline(always)]
+            #[deny(unreachable_patterns)]
             fn route(storage: &mut S, selector: u32, input: &[u8]) -> Option<stylus_sdk::ArbResult> {
                 use stylus_sdk::{function_selector, alloy_sol_types::SolType};
                 use stylus_sdk::abi::{internal, internal::EncodableReturnType, AbiType, Router};


### PR DESCRIPTION
## Description

Ensure that selectors are unique. This prevents both unintentional function shadowing, as well as potentially malicious, intentional unreachable methods.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
