### PR TITLE
Fix SolType trait for ints in alloy 0.7.7

### DIFF
--- a/stylus-sdk/src/abi/ints.rs
+++ b/stylus-sdk/src/abi/ints.rs
@@ -47,6 +47,7 @@ where
         .concat(ConstString::from_decimal_number(BITS))
         .as_str();
     const ENCODED_SIZE: Option<usize> = Some(32);
+    const PACKED_ENCODED_SIZE: Option<usize> = Some(BITS / 8);
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {
@@ -120,6 +121,7 @@ where
         .concat(ConstString::from_decimal_number(BITS))
         .as_str();
     const ENCODED_SIZE: Option<usize> = Some(32);
+    const PACKED_ENCODED_SIZE: Option<usize> = Some(BITS / 8);
 
     #[inline]
     fn valid_token(token: &Self::Token<'_>) -> bool {


### PR DESCRIPTION
## Description

Alloy 0.7.7 and the alloy_primitves int type changes were incompatible due to a trait const being added. Fixed by this PR.

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
