### PR TITLE
Fix return encoding for sequence types

### DIFF
--- a/stylus-sdk/src/abi/internal.rs
+++ b/stylus-sdk/src/abi/internal.rs
@@ -21,9 +21,7 @@ where
     #[inline(always)]
     fn encode(self) -> ArbResult {
         // coerce types into a tuple of at least 1 element
-        Ok(<(<T as AbiType>::SolType,) as SolType>::abi_encode(
-            &(self,),
-        ))
+        Ok(<<T as AbiType>::SolType>::abi_encode(&self))
     }
 }
 


### PR DESCRIPTION
## Description

Fixes incorrect usage of alloy encoding for new alloy version

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
