### PR TITLE
Fix off-by-one error when string len is 32

### DIFF
--- a/stylus-sdk/src/storage/bytes.rs
+++ b/stylus-sdk/src/storage/bytes.rs
@@ -216,7 +216,7 @@ impl StorageBytes {
     /// Determines the slot and offset for the element at an index.
     fn index_slot(&self, index: usize) -> (U256, u8) {
         let slot = match self.len() {
-            33.. => self.base() + U256::from(index / 32),
+            32.. => self.base() + U256::from(index / 32),
             _ => self.root,
         };
         (slot, (index % 32) as u8)


### PR DESCRIPTION
## Description

Fix storage of strings with length 32. Was previously treating these strings as short which would cause reading the root slot instead of the base slot.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
