### PR TITLE
Fallback receive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0458ccb02a564228fcd76efb8eb5a520521a8347becde37b402afec9a1b83859"
+checksum = "661c516eb1fa3294cc7f2fb8955b3b609d639c282ac81a4eedb14d3046db503a"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc65475025fc1e84bf86fc840f04f63fcccdcf3cf12053c99918e4054dfbc69"
+checksum = "ecbabb8fc3d75a0c2cea5215be22e7a267e3efde835b0f2a8922f5e3f5d47683"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed10f0715a0b69fde3236ff3b9ae5f6f7c97db5a387747100070d3016b9266b"
+checksum = "16517f2af03064485150d89746b8ffdcdbc9b6eeb3d536fb66efd7c2846fbc75"
 dependencies = [
  "const-hex",
  "dunce",
@@ -696,9 +696,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.3"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b95156f8b577cb59dc0b1df15c6f29a10afc5f8a7ac9786b0b5c68c19149278"
+checksum = "20e7b52ad118b2153644eea95c6fc740b6c1555b2344fdab763fc9de4075f665"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ proc-macro-error = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
 regex = "1.10.6"
-syn = { version = "2.0", features = ["full", "visit-mut"] }
+syn = { version = "2.0.77", features = ["full", "visit-mut"] }
 syn-solidity = "0.8.3"
 
 # proc macro dev

--- a/stylus-proc/src/imports.rs
+++ b/stylus-proc/src/imports.rs
@@ -60,6 +60,7 @@ pub mod stylus_sdk {
         use crate::imports::ConstPath;
 
         pub const AbiType: ConstPath = ConstPath("stylus_sdk::abi::AbiType");
+        pub const Router: ConstPath = ConstPath("stylus_sdk::abi::Router");
     }
 }
 

--- a/stylus-proc/src/macros/entrypoint.rs
+++ b/stylus-proc/src/macros/entrypoint.rs
@@ -30,7 +30,6 @@ struct Entrypoint {
     mark_used_fn: syn::ItemFn,
     user_entrypoint_fn: syn::ItemFn,
 }
-
 impl Parse for Entrypoint {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let item: syn::Item = input.parse()?;
@@ -40,6 +39,7 @@ impl Parse for Entrypoint {
                 top_level_storage_impl: top_level_storage_impl(&item),
                 struct_entrypoint_fn: struct_entrypoint_fn(&item.ident),
                 assert_overrides_const: assert_overrides_const(&item.ident),
+                print_abi_fn: print_abi_fn(&item.ident),
                 item,
             }),
             _ => abort!(item, "not a struct or fn"),
@@ -103,6 +103,7 @@ struct EntrypointStruct {
     top_level_storage_impl: syn::ItemImpl,
     struct_entrypoint_fn: syn::ItemFn,
     assert_overrides_const: syn::ItemConst,
+    print_abi_fn: Option<syn::ItemFn>,
 }
 
 impl ToTokens for EntrypointStruct {
@@ -111,6 +112,7 @@ impl ToTokens for EntrypointStruct {
         self.top_level_storage_impl.to_tokens(tokens);
         self.struct_entrypoint_fn.to_tokens(tokens);
         self.assert_overrides_const.to_tokens(tokens);
+        self.print_abi_fn.to_tokens(tokens);
     }
 }
 
@@ -178,6 +180,21 @@ fn deny_reentrant() -> Option<syn::ExprIf> {
                     return 1; // revert
                 }
             })
+        }
+    }
+}
+
+fn print_abi_fn(ident: &syn::Ident) -> Option<syn::ItemFn> {
+    let _ = ident;
+    cfg_if! {
+        if #[cfg(feature = "export-abi")] {
+            Some(parse_quote! {
+                pub fn print_abi(license: &str, pragma: &str) {
+                    stylus_sdk::abi::export::print_abi::<#ident>(license, pragma);
+                }
+            })
+        } else {
+            None
         }
     }
 }

--- a/stylus-proc/src/macros/entrypoint.rs
+++ b/stylus-proc/src/macros/entrypoint.rs
@@ -125,23 +125,7 @@ fn top_level_storage_impl(item: &syn::ItemStruct) -> syn::ItemImpl {
 fn struct_entrypoint_fn(name: &Ident) -> syn::ItemFn {
     parse_quote! {
         fn #STRUCT_ENTRYPOINT_FN(input: alloc::vec::Vec<u8>) -> stylus_sdk::ArbResult {
-            use stylus_sdk::{abi::Router, alloy_primitives::U256, console, hex, storage::StorageType};
-            use core::convert::TryInto;
-            use alloc::vec;
-
-            if input.len() < 4 {
-                console!("calldata too short: {}", hex::encode(input));
-                return Err(vec![]);
-            }
-            let selector = u32::from_be_bytes(TryInto::try_into(&input[..4]).unwrap());
-            let mut storage = unsafe { <#name as StorageType>::new(U256::ZERO, 0) };
-            match <#name as Router<_>>::route(&mut storage, selector, &input[4..]) {
-                Some(res) => res,
-                None => {
-                    console!("unknown method selector: {selector:08x}");
-                    Err(vec![])
-                },
-            }
+            stylus_sdk::abi::router_entrypoint::<#name, #name>(input)
         }
     }
 }

--- a/stylus-proc/src/macros/public/export_abi.rs
+++ b/stylus-proc/src/macros/public/export_abi.rs
@@ -7,7 +7,7 @@ use syn::parse_quote;
 
 use crate::types::Purity;
 
-use super::types::{FnArgExtension, FnExtension, InterfaceExtension, PublicImpl};
+use super::types::{FnArgExtension, FnExtension, FnKind, InterfaceExtension, PublicImpl};
 
 #[derive(Debug)]
 pub struct InterfaceAbi;
@@ -64,6 +64,10 @@ impl InterfaceExtension for InterfaceAbi {
 
         let mut abi = TokenStream::new();
         for func in funcs {
+            if !matches!(func.kind, FnKind::Function) {
+                continue;
+            }
+
             let sol_name = func.sol_name.to_string();
             let sol_args = func.inputs.iter().enumerate().map(|(i, arg)| {
                 let comma = (i > 0).then_some(", ").unwrap_or_default();

--- a/stylus-proc/src/macros/public/mod.rs
+++ b/stylus-proc/src/macros/public/mod.rs
@@ -15,7 +15,9 @@ use crate::{
         split_item_impl_for_impl,
     },
 };
-use types::{FnArgExtension, FnExtension, InterfaceExtension, PublicFn, PublicFnArg, PublicImpl};
+use types::{
+    FnArgExtension, FnExtension, FnKind, InterfaceExtension, PublicFn, PublicFnArg, PublicImpl,
+};
 
 mod attrs;
 mod overrides;
@@ -96,6 +98,18 @@ impl<E: FnExtension> From<&mut syn::ImplItemFn> for PublicFn<E> {
         let payable = consume_flag(&mut node.attrs, "payable");
         let selector_override =
             consume_attr::<attrs::Selector>(&mut node.attrs, "selector").map(|s| s.value.value());
+        let fallback = consume_flag(&mut node.attrs, "fallback");
+        let receive = consume_flag(&mut node.attrs, "receive");
+
+        let kind = match (fallback, receive) {
+            (true, false) => FnKind::Fallback,
+            (false, true) => FnKind::Receive,
+            (false, false) => FnKind::Function,
+            (true, true) => {
+                emit_error!(node.span(), "function cannot be both fallback and receive");
+                FnKind::Function
+            }
+        };
 
         // name for generated rust, and solidity abi
         let name = node.sig.ident.clone();
@@ -105,7 +119,7 @@ impl<E: FnExtension> From<&mut syn::ImplItemFn> for PublicFn<E> {
 
         // determine state mutability
         let (inferred_purity, has_self) = Purity::infer(node);
-        let purity = if payable {
+        let purity = if payable || matches!(kind, FnKind::Receive) {
             Purity::Payable
         } else {
             inferred_purity
@@ -134,6 +148,7 @@ impl<E: FnExtension> From<&mut syn::ImplItemFn> for PublicFn<E> {
             sol_name,
             purity,
             inferred_purity,
+            kind,
 
             has_self,
             inputs,

--- a/stylus-proc/src/macros/public/mod.rs
+++ b/stylus-proc/src/macros/public/mod.rs
@@ -130,7 +130,10 @@ impl<E: FnExtension> From<&mut syn::ImplItemFn> for PublicFn<E> {
             // skip self or storage argument
             args.next();
         }
-        let inputs = args.map(PublicFnArg::from).collect();
+        let inputs = match kind {
+            FnKind::Function => args.map(PublicFnArg::from).collect(),
+            _ => Vec::new(),
+        };
         let input_span = node.sig.inputs.span();
 
         let output = match &node.sig.output {

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -16,11 +16,16 @@
 //!
 
 use alloc::vec::Vec;
+use alloy_primitives::U256;
 use core::borrow::BorrowMut;
 
 use alloy_sol_types::{abi::TokenSeq, private::SolTypeValue, SolType};
 
-use crate::{storage::TopLevelStorage, ArbResult};
+use crate::{
+    console,
+    storage::{StorageType, TopLevelStorage},
+    ArbResult,
+};
 
 pub use bytes::{Bytes, BytesSolType};
 pub use const_string::ConstString;
@@ -53,6 +58,56 @@ where
     /// Routes add via `#[inherit]` will only execute if no match is found among `Self`.
     /// This means that it is possible to override a method by redefining it in `Self`.
     fn route(storage: &mut S, selector: u32, input: &[u8]) -> Option<ArbResult>;
+
+    /// Fallback function for this contract. Called when no route is matched or no calldata is
+    /// provided and there is no receive function.
+    fn fallback(storage: &mut S, calldata: &[u8]) -> Option<ArbResult>;
+
+    /// Receive function for this contract. Called when no calldata is provided.
+    fn receive(storage: &mut S) -> Option<ArbResult>;
+}
+
+/// Entrypoint used when `#[entrypoint]` is used on a contract struct.
+pub fn router_entrypoint<R, S>(input: alloc::vec::Vec<u8>) -> ArbResult
+where
+    R: Router<S>,
+    S: StorageType + TopLevelStorage + BorrowMut<R::Storage>,
+{
+    let mut storage = unsafe { S::new(U256::ZERO, 0) };
+
+    if input.is_empty() {
+        // Try receive function.
+        if let Some(res) = R::receive(&mut storage) {
+            return res;
+        }
+
+        // Try fallback function.
+        if let Some(res) = R::fallback(&mut storage, &[]) {
+            return res;
+        }
+
+        console!("no calldata provided");
+        return Err(Vec::new());
+    }
+
+    if input.len() < 4 {
+        console!("calldata too short: {}", stylus_sdk::hex::encode(input));
+        return Err(Vec::new());
+    }
+
+    // Try selector routes.
+    let selector = u32::from_be_bytes(TryInto::try_into(&input[..4]).unwrap());
+    if let Some(res) = R::route(&mut storage, selector, &input[4..]) {
+        return res;
+    }
+
+    // Try fallback function.
+    if let Some(res) = R::fallback(&mut storage, &input) {
+        return res;
+    }
+
+    console!("unknown method selector: {selector:08x}");
+    Err(Vec::new())
 }
 
 /// Provides a mapping of Rust to Solidity types.

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -91,7 +91,7 @@ where
     }
 
     if input.len() < 4 {
-        console!("calldata too short: {}", stylus_sdk::hex::encode(input));
+        console!("calldata too short: {}", crate::hex::encode(input));
         return Err(Vec::new());
     }
 


### PR DESCRIPTION
## Description

Fallback/receive support.

These functions currently support returning `ArbResult` and fallback always takes `calldata: &[u8]` as a parameter.

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
