### PR TITLE
Update alloy to 0.7.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f783611babedbbe90db3478c120fb5f5daacceffc210b39adc0af4fe0da70bad"
+checksum = "ccb3ead547f4532bc8af961649942f0b9c16ee9226e26caa3f38420651cc0bf4"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bad41a7c19498e3f6079f7744656328699f8ea3e783bdd10d85788cd439f572"
+checksum = "2b40397ddcdcc266f59f959770f601ce1280e699a91fc1862f29cef91707cd09"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9899da7d011b4fe4c406a524ed3e3f963797dbc93b45479d60341d3a27b252"
+checksum = "867a5469d61480fea08c7333ffeca52d5b621f5ca2e44f271b117ec1fc9a0525"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32d595768fdc61331a132b6f65db41afae41b9b97d36c21eb1b955c422a7e60"
+checksum = "2e482dc33a32b6fadbc0f599adea520bd3aaa585c141a80b404d0a3e3fa72528"
 dependencies = [
  "const-hex",
  "dunce",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49042c6d3b66a9fe6b2b5a8bf0d39fc2ae1ee0310a2a26ffedd79fb097878dd"
+checksum = "a91ca40fa20793ae9c3841b83e74569d1cc9af29a2f5237314fd3452d51e38c7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d71e19bca02c807c9faa67b5a47673ff231b6e7449b251695188522f1dc44b2"
+checksum = "c837dc8852cb7074e46b444afb81783140dab12c58867b49fb3898fbafedf7ea"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/OffchainLabs/stylus-sdk-rs"
 rust-version = "1.71.0"
 
 [workspace.dependencies]
-alloy-primitives = { version = "=0.7.6", default-features = false , features = ["native-keccak"] }
-alloy-sol-types = { version = "=0.7.6", default-features = false }
+alloy-primitives = { version = "=0.7.7", default-features = false , features = ["native-keccak"] }
+alloy-sol-types = { version = "=0.7.7", default-features = false }
 cfg-if = "1.0.0"
 derivative = { version = "2.2.0", features = ["use_core"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
@@ -27,7 +27,7 @@ paste = "1.0.14"
 quote = "1.0"
 regex = "1.9.1"
 proc-macro2 = "1.0"
-syn-solidity = "0.7.6"
+syn-solidity = "=0.7.7"
 convert_case = "0.6.0"
 
 # members

--- a/stylus-proc/src/calls/mod.rs
+++ b/stylus-proc/src/calls/mod.rs
@@ -226,6 +226,7 @@ pub fn sol_interface(input: TokenStream) -> TokenStream {
                 const SOL_NAME: &'static str = <#sol_address as #sol_type>::SOL_NAME;
 
                 const ENCODED_SIZE: Option<usize> = <#sol_address as #sol_type>::ENCODED_SIZE;
+                const PACKED_ENCODED_SIZE: Option<usize> = <#sol_address as #sol_type>::PACKED_ENCODED_SIZE;
 
                 fn valid_token(token: &Self::Token<'_>) -> bool {
                     <#sol_address as #sol_type>::valid_token(token)

--- a/stylus-sdk/src/abi/bytes.rs
+++ b/stylus-sdk/src/abi/bytes.rs
@@ -86,6 +86,7 @@ impl SolType for Bytes {
     type Token<'a> = PackedSeqToken<'a>;
 
     const ENCODED_SIZE: Option<usize> = None;
+    const PACKED_ENCODED_SIZE: Option<usize> = None;
 
     const SOL_NAME: &'static str = "bytes";
 


### PR DESCRIPTION
## Description

Update alloy to 0.7.7 to fix conflicting alloy package versions.

While `alloy-primitives` and `alloy-sol-types` dependencies were specified with exact version (=0.7.6), other alloy dependencies were imported indirectly and resolved to 0.7.7 which led to conflicts between different alloy types.

This specifically affected `sol!` macro from `alloy-sol-macro 0.7.7`, which is not compatible with other alloy crates of version 0.7.6. 

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
