### PR TITLE
Remove support for broken storage ints

### DIFF
--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -24,7 +24,7 @@
 
 use crate::hostio;
 use alloy_primitives::{Address, BlockHash, BlockNumber, FixedBytes, Signed, Uint, B256, U256};
-use alloy_sol_types::sol_data::{ByteCount, SupportedFixedBytes};
+use alloy_sol_types::sol_data::{ByteCount, IntBitCount, SupportedFixedBytes, SupportedInt};
 use core::{cell::OnceCell, marker::PhantomData, ops::Deref};
 
 pub use array::StorageArray;
@@ -141,13 +141,19 @@ alias_bytes! {
 // TODO: drop L after SupportedInt provides LIMBS (waiting for clarity reasons)
 // https://github.com/rust-lang/rust/issues/76560
 #[derive(Debug)]
-pub struct StorageUint<const B: usize, const L: usize> {
+pub struct StorageUint<const B: usize, const L: usize>
+where
+    IntBitCount<B>: SupportedInt,
+{
     slot: U256,
     offset: u8,
     cached: OnceCell<Uint<B, L>>,
 }
 
-impl<const B: usize, const L: usize> StorageUint<B, L> {
+impl<const B: usize, const L: usize> StorageUint<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     /// Gets the underlying [`alloy_primitives::Uint`] in persistent storage.
     pub fn get(&self) -> Uint<B, L> {
         **self
@@ -160,7 +166,10 @@ impl<const B: usize, const L: usize> StorageUint<B, L> {
     }
 }
 
-impl<const B: usize, const L: usize> StorageType for StorageUint<B, L> {
+impl<const B: usize, const L: usize> StorageType for StorageUint<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     type Wraps<'a> = Uint<B, L>;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
 
@@ -184,19 +193,28 @@ impl<const B: usize, const L: usize> StorageType for StorageUint<B, L> {
     }
 }
 
-impl<'a, const B: usize, const L: usize> SimpleStorageType<'a> for StorageUint<B, L> {
+impl<'a, const B: usize, const L: usize> SimpleStorageType<'a> for StorageUint<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     fn set_by_wrapped(&mut self, value: Self::Wraps<'a>) {
         self.set(value);
     }
 }
 
-impl<const B: usize, const L: usize> Erase for StorageUint<B, L> {
+impl<const B: usize, const L: usize> Erase for StorageUint<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     fn erase(&mut self) {
         self.set(Self::Wraps::ZERO);
     }
 }
 
-impl<const B: usize, const L: usize> Deref for StorageUint<B, L> {
+impl<const B: usize, const L: usize> Deref for StorageUint<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     type Target = Uint<B, L>;
 
     fn deref(&self) -> &Self::Target {
@@ -205,7 +223,10 @@ impl<const B: usize, const L: usize> Deref for StorageUint<B, L> {
     }
 }
 
-impl<const B: usize, const L: usize> From<StorageUint<B, L>> for Uint<B, L> {
+impl<const B: usize, const L: usize> From<StorageUint<B, L>> for Uint<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     fn from(value: StorageUint<B, L>) -> Self {
         *value
     }
@@ -217,13 +238,19 @@ impl<const B: usize, const L: usize> From<StorageUint<B, L>> for Uint<B, L> {
 // TODO: drop L after SupportedInt provides LIMBS (waiting for clarity reasons)
 // https://github.com/rust-lang/rust/issues/76560
 #[derive(Debug)]
-pub struct StorageSigned<const B: usize, const L: usize> {
+pub struct StorageSigned<const B: usize, const L: usize>
+where
+    IntBitCount<B>: SupportedInt,
+{
     slot: U256,
     offset: u8,
     cached: OnceCell<Signed<B, L>>,
 }
 
-impl<const B: usize, const L: usize> StorageSigned<B, L> {
+impl<const B: usize, const L: usize> StorageSigned<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     /// Gets the underlying [`Signed`] in persistent storage.
     pub fn get(&self) -> Signed<B, L> {
         **self
@@ -236,7 +263,10 @@ impl<const B: usize, const L: usize> StorageSigned<B, L> {
     }
 }
 
-impl<const B: usize, const L: usize> StorageType for StorageSigned<B, L> {
+impl<const B: usize, const L: usize> StorageType for StorageSigned<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     type Wraps<'a> = Signed<B, L>;
     type WrapsMut<'a> = StorageGuardMut<'a, Self>;
 
@@ -259,19 +289,28 @@ impl<const B: usize, const L: usize> StorageType for StorageSigned<B, L> {
     }
 }
 
-impl<'a, const B: usize, const L: usize> SimpleStorageType<'a> for StorageSigned<B, L> {
+impl<'a, const B: usize, const L: usize> SimpleStorageType<'a> for StorageSigned<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     fn set_by_wrapped(&mut self, value: Self::Wraps<'a>) {
         self.set(value);
     }
 }
 
-impl<const B: usize, const L: usize> Erase for StorageSigned<B, L> {
+impl<const B: usize, const L: usize> Erase for StorageSigned<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     fn erase(&mut self) {
         self.set(Self::Wraps::ZERO)
     }
 }
 
-impl<const B: usize, const L: usize> Deref for StorageSigned<B, L> {
+impl<const B: usize, const L: usize> Deref for StorageSigned<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     type Target = Signed<B, L>;
 
     fn deref(&self) -> &Self::Target {
@@ -280,7 +319,10 @@ impl<const B: usize, const L: usize> Deref for StorageSigned<B, L> {
     }
 }
 
-impl<const B: usize, const L: usize> From<StorageSigned<B, L>> for Signed<B, L> {
+impl<const B: usize, const L: usize> From<StorageSigned<B, L>> for Signed<B, L>
+where
+    IntBitCount<B>: SupportedInt,
+{
     fn from(value: StorageSigned<B, L>) -> Self {
         *value
     }

--- a/stylus-sdk/src/storage/traits.rs
+++ b/stylus-sdk/src/storage/traits.rs
@@ -297,6 +297,7 @@ pub trait GlobalStorage {
         offset: usize,
         value: Uint<B, L>,
     ) {
+        debug_assert!(B % 8 == 0);
         debug_assert!(B / 8 + offset <= 32);
 
         if B == 256 {


### PR DESCRIPTION
## Description


    Previousy it was possible to define storage for ints and uints which
    whose bit size was not divisible by 8. This was both broken, and is not
    intended as a supported feature of Stylus. This has been changed into a
    compile-time error to avoid using these broken types.

    This fixes issue C-01 from the OpenZeppelin 0.7.0 audit.

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
