### PR TITLE
Allow impl items

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,6 @@ prettyplease = "0.2.22"
 trybuild = "1.0"
 
 # members
-mini-alloc = { path = "mini-alloc", version = "0.6.0" }
+mini-alloc = { path = "mini-alloc", version = "0.7.0-beta.0" }
 stylus-sdk = { path = "stylus-sdk" }
 stylus-proc = { path = "stylus-proc", version = "0.7.0-beta.0" }

--- a/stylus-proc/src/macros/public/mod.rs
+++ b/stylus-proc/src/macros/public/mod.rs
@@ -36,7 +36,6 @@ cfg_if! {
 ///
 /// This implementation performs the following steps:
 /// - Parse the input as [`syn::ItemImpl`]
-/// - Use [`PublicImplVisitor`] to collect the public functions and handle attribtes
 /// - Generate AST items within a [`PublicImpl`]
 /// - Expand those AST items into tokens for output
 pub fn public(attr: TokenStream, input: TokenStream) -> TokenStream {

--- a/stylus-proc/src/macros/public/mod.rs
+++ b/stylus-proc/src/macros/public/mod.rs
@@ -70,8 +70,12 @@ impl From<&mut syn::ItemImpl> for PublicImpl {
             .iter_mut()
             .filter_map(|item| match item {
                 syn::ImplItem::Fn(func) => Some(PublicFn::from(func)),
-                _ => {
+                syn::ImplItem::Const(_) => {
                     emit_error!(item, "unsupported impl item");
+                    None
+                }
+                _ => {
+                    // allow other item types
                     None
                 }
             })

--- a/stylus-proc/tests/fail/public/generated.stderr
+++ b/stylus-proc/tests/fail/public/generated.stderr
@@ -39,16 +39,7 @@ error[E0277]: the trait bound `UnsupportedType: EncodableReturnType` is not sati
 18 |     fn unsupported_output() -> UnsupportedType {
    |                                ^^^^^^^^^^^^^^^ the trait `AbiType` is not implemented for `UnsupportedType`, which is required by `UnsupportedType: EncodableReturnType`
    |
-   = help: the following other types implement trait `AbiType`:
-             ()
-             (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X)
-             (B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X)
-             (C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X)
-             (D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X)
-             (E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X)
-             (F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X)
-             (G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X)
-           and $N others
+   = help: the trait `EncodableReturnType` is implemented for `Result<T, E>`
    = note: required for `UnsupportedType` to implement `EncodableReturnType`
 
 error: could not evaluate constant pattern


### PR DESCRIPTION
## Description

Allows impl items that are not `const` inside `#[public]` macro.

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
