### PR TITLE
Use Interior Mutability in Static References to Host I/O Caches

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.83.0"

--- a/stylus-sdk/src/call/raw.rs
+++ b/stylus-sdk/src/call/raw.rs
@@ -224,9 +224,7 @@ impl RawCall {
                 }
             };
 
-            unsafe {
-                RETURN_DATA_LEN.set(outs_len);
-            }
+            RETURN_DATA_LEN.set(outs_len);
 
             let outs = read_return_data(self.offset, self.size);
             match status {

--- a/stylus-sdk/src/storage/array.rs
+++ b/stylus-sdk/src/storage/array.rs
@@ -12,8 +12,14 @@ pub struct StorageArray<S: StorageType, const N: usize> {
 }
 
 impl<S: StorageType, const N: usize> StorageType for StorageArray<S, N> {
-    type Wraps<'a> = StorageGuard<'a, StorageArray<S, N>> where Self: 'a;
-    type WrapsMut<'a> = StorageGuardMut<'a, StorageArray<S, N>> where Self: 'a;
+    type Wraps<'a>
+        = StorageGuard<'a, StorageArray<S, N>>
+    where
+        Self: 'a;
+    type WrapsMut<'a>
+        = StorageGuardMut<'a, StorageArray<S, N>>
+    where
+        Self: 'a;
 
     const REQUIRED_SLOTS: usize = Self::required_slots();
 

--- a/stylus-sdk/src/storage/bytes.rs
+++ b/stylus-sdk/src/storage/bytes.rs
@@ -17,8 +17,14 @@ pub struct StorageBytes {
 }
 
 impl StorageType for StorageBytes {
-    type Wraps<'a> = StorageGuard<'a, StorageBytes> where Self: 'a;
-    type WrapsMut<'a> = StorageGuardMut<'a, StorageBytes> where Self: 'a;
+    type Wraps<'a>
+        = StorageGuard<'a, StorageBytes>
+    where
+        Self: 'a;
+    type WrapsMut<'a>
+        = StorageGuardMut<'a, StorageBytes>
+    where
+        Self: 'a;
 
     unsafe fn new(root: U256, offset: u8) -> Self {
         debug_assert!(offset == 0);
@@ -262,8 +268,14 @@ impl<'a> Extend<&'a u8> for StorageBytes {
 pub struct StorageString(pub StorageBytes);
 
 impl StorageType for StorageString {
-    type Wraps<'a> = StorageGuard<'a, StorageString> where Self: 'a;
-    type WrapsMut<'a> = StorageGuardMut<'a, StorageString> where Self: 'a;
+    type Wraps<'a>
+        = StorageGuard<'a, StorageString>
+    where
+        Self: 'a;
+    type WrapsMut<'a>
+        = StorageGuardMut<'a, StorageString>
+    where
+        Self: 'a;
 
     unsafe fn new(slot: U256, offset: u8) -> Self {
         Self(StorageBytes::new(slot, offset))

--- a/stylus-sdk/src/storage/map.rs
+++ b/stylus-sdk/src/storage/map.rs
@@ -19,8 +19,14 @@ where
     K: StorageKey,
     V: StorageType,
 {
-    type Wraps<'a> = StorageGuard<'a, StorageMap<K, V>> where Self: 'a;
-    type WrapsMut<'a> = StorageGuardMut<'a, StorageMap<K, V>> where Self: 'a;
+    type Wraps<'a>
+        = StorageGuard<'a, StorageMap<K, V>>
+    where
+        Self: 'a;
+    type WrapsMut<'a>
+        = StorageGuardMut<'a, StorageMap<K, V>>
+    where
+        Self: 'a;
 
     unsafe fn new(slot: U256, offset: u8) -> Self {
         debug_assert!(offset == 0);

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -698,8 +698,14 @@ impl From<StorageBlockHash> for BlockHash {
 
 /// We implement `StorageType` for `PhantomData` so that storage types can be generic.
 impl<T> StorageType for PhantomData<T> {
-    type Wraps<'a> = Self where Self: 'a;
-    type WrapsMut<'a> = Self where Self: 'a;
+    type Wraps<'a>
+        = Self
+    where
+        Self: 'a;
+    type WrapsMut<'a>
+        = Self
+    where
+        Self: 'a;
 
     const REQUIRED_SLOTS: usize = 0;
     const SLOT_BYTES: usize = 0;

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -16,8 +16,14 @@ pub struct StorageVec<S: StorageType> {
 }
 
 impl<S: StorageType> StorageType for StorageVec<S> {
-    type Wraps<'a> = StorageGuard<'a, StorageVec<S>> where Self: 'a;
-    type WrapsMut<'a> = StorageGuardMut<'a, StorageVec<S>> where Self: 'a;
+    type Wraps<'a>
+        = StorageGuard<'a, StorageVec<S>>
+    where
+        Self: 'a;
+    type WrapsMut<'a>
+        = StorageGuardMut<'a, StorageVec<S>>
+    where
+        Self: 'a;
 
     unsafe fn new(slot: U256, offset: u8) -> Self {
         debug_assert!(offset == 0);


### PR DESCRIPTION
## Description

**This PR allows the Stylus SDK to use Rust 1.83**

Currently, the Stylus SDK defines hostios via a macro called `wrap_hostio` which ends up producing two things:
1. A function that allows the user to conveniently call the hostio in more idiomatic, safe Rust, such as `fn base_fee(block_number: u64) -> U256`
2. A mutable static reference to a cache for recently called hostios. For instance, if the program recently called `base_fee()`, it will cache the result in a static variable called `BASE_FEE`

Today, this static variable is a mutable static reference to a struct called `CachedOption<T>`. It looks a bit like this:

```rust
pub(crate) static mut BASE_FEE: hostio::CachedOption<u64> = hostio::CachedOption::new(|| {
    let mut data = ...
    unsafe { hostio::base_fee(data.as_mut_ptr()) };
    data.into()
});
```

It's a wrapper type around an `Option<T>`, where if you call it the first time and it is None, it defaults to the result of a closure specified on initialization.

However, as of [Rust 1.83](https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html), other parts of the codebase cannot take references to a static mut variable. This is now a compilation error.

Instead, we need to leverage [interior mutability](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html).

### The Solution

Our solution is to change all hostio caches to `static` instead of `static mut` and allow for interior mutability. We leverage the `UnsafeCell` and `MaybeUninit` types from the `core` crate, which are the basis for many interior mutability items in the Rust standard library already.

We refactor our cached option type as follows:

```rs
pub(crate) struct CachedOption<T: Copy> {
    value: UnsafeCell<MaybeUninit<T>>,
    initialized: UnsafeCell<bool>,
    loader: fn() -> T,
}
```
Essentially, value being unsafe cell gives us interior mutability without needing a mutable reference, and initialized is a bool that tells us if we have filled in the value. In Rust, all statics must implement `Sync`, so we have to do an unsafe impl Sync to satisfy the compiler. The safety is that Stylus programs are single-threaded by nature of WASM. Moreover, the get and set methods of our CachedOptions have the safety guarantees that they will always be called from a single-threaded context.
```rs
    /// # Safety
    /// Must only be called from a single-threaded context.
    pub fn set(&self, value: T) {
        unsafe {
            (*self.value.get()).write(value);
            *self.initialized.get() = true;
        }
    }
```

