### PR TITLE
feat: add hostio-caching feature

### DIFF
--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -34,10 +34,11 @@ sha3.workspace = true
 features = ["default", "docs", "debug", "export-abi"]
 
 [features]
-default = ["mini-alloc"]
+default = ["mini-alloc", "hostio-caching"]
 export-abi = ["debug", "regex", "stylus-proc/export-abi", "alloy-primitives/tiny-keccak"]
 debug = []
 docs = []
 hostio = []
 mini-alloc = ["dep:mini-alloc"]
 reentrant = ["stylus-proc/reentrant"]
+hostio-caching = []

--- a/stylus-sdk/src/call/raw.rs
+++ b/stylus-sdk/src/call/raw.rs
@@ -1,10 +1,7 @@
 // Copyright 2023-2024, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
 
-use crate::{
-    contract::{read_return_data, RETURN_DATA_LEN},
-    hostio, tx, ArbResult,
-};
+use crate::{contract::read_return_data, hostio, tx, ArbResult};
 use alloy_primitives::{Address, B256, U256};
 use cfg_if::cfg_if;
 
@@ -188,7 +185,7 @@ impl RawCall {
         /// [`flush_storage_cache`]: RawCall::flush_storage_cache
         /// [`clear_storage_cache`]: RawCall::clear_storage_cache
         pub fn call(self, contract: Address, calldata: &[u8]) -> ArbResult {
-            let mut outs_len = 0;
+            let mut outs_len: usize = 0;
             let gas = self.gas.unwrap_or(u64::MAX); // will be clamped by 63/64 rule
             let value = B256::from(self.callvalue);
             let status = unsafe {
@@ -224,7 +221,11 @@ impl RawCall {
                 }
             };
 
-            RETURN_DATA_LEN.set(outs_len);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "hostio-caching")] {
+                    crate::contract::RETURN_DATA_LEN.set(outs_len);
+                }
+            }
 
             let outs = read_return_data(self.offset, self.size);
             match status {


### PR DESCRIPTION
## Description

Provides the default feature `hostio-caching` to `stylus-sdk`.
When disabled, any function that uses caching behavior to query a host node will stop doing so.

e.g. `msg::sender()` would query actual sender from host node each time (not just once), when `hostio-caching` feature disabled.

Extremely convenient for unit test mocks.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
