### PR TITLE
Allow Receive Fn to Return Error

### DIFF
--- a/stylus-proc/src/macros/public/types.rs
+++ b/stylus-proc/src/macros/public/types.rs
@@ -117,7 +117,7 @@ impl PublicImpl {
                 }
 
                 #[inline(always)]
-                fn receive(storage: &mut S) -> Option<()> {
+                fn receive(storage: &mut S) -> Option<Result<(), Vec<u8>>> {
                     #receive
                 }
             }

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -64,7 +64,7 @@ where
     /// Receive functions are always payable, take in no inputs, and return no outputs.
     /// If defined, they will always be called when a transaction does not send any
     /// calldata, regardless of the transaction having a value attached.
-    fn receive(storage: &mut S) -> Option<()>;
+    fn receive(storage: &mut S) -> Option<Result<(), Vec<u8>>>;
 
     /// Called when no receive function is defined.
     /// If no #[fallback] function is defined in the contract, then any transactions that do not
@@ -105,7 +105,10 @@ where
 
     if input.is_empty() {
         console!("no calldata provided");
-        if R::receive(&mut storage).is_some() {
+        if let Some(res) = R::receive(&mut storage) {
+            if let Err(e) = res {
+                return Err(e);
+            }
             return Ok(Vec::new());
         }
         // Try fallback function with no inputs if defined.

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -106,10 +106,7 @@ where
     if input.is_empty() {
         console!("no calldata provided");
         if let Some(res) = R::receive(&mut storage) {
-            if let Err(e) = res {
-                return Err(e);
-            }
-            return Ok(Vec::new());
+            return res.map(|_| Vec::new());
         }
         // Try fallback function with no inputs if defined.
         if let Some(res) = R::fallback(&mut storage, &[]) {


### PR DESCRIPTION
This PR allows the receive method to return an error, but maintains that the Ok result should be the unit type, as a receive function can never return an output argument