### PR TITLE
Ensure Fallback No Args Returns Result with Unit Type OK

### DIFF
--- a/stylus-proc/src/macros/public/types.rs
+++ b/stylus-proc/src/macros/public/types.rs
@@ -332,7 +332,13 @@ impl<E: FnExtension> PublicFn<E> {
         let storage_arg = self.storage_arg();
         if matches!(self.kind, FnKind::FallbackNoArgs) {
             return parse_quote! {
-                return Some(Self::#name(#storage_arg));
+                return Some({
+                    if let Err(err) = Self::#name(#storage_arg) {
+                       Err(err)
+                    } else {
+                        Ok(Vec::new())
+                    }
+                });
             };
         }
         parse_quote! {


### PR DESCRIPTION
This PR ensures that a fallback with no args is required to return Result<(), Vec<u8>> instead of Result<Vec<u8>, Vec<u8>> as its counterpart does