### PR TITLE
Enforce No Args Fallback Return Type

### DIFF
--- a/stylus-proc/src/macros/public/types.rs
+++ b/stylus-proc/src/macros/public/types.rs
@@ -333,10 +333,9 @@ impl<E: FnExtension> PublicFn<E> {
         if matches!(self.kind, FnKind::FallbackNoArgs) {
             return parse_quote! {
                 return Some({
-                    if let Err(err) = Self::#name(#storage_arg) {
-                       Err(err)
-                    } else {
-                        Ok(Vec::new())
+                    match Self::#name(#storage_arg) {
+                        Ok(()) => Ok(Vec::new()),
+                        Err(err) => Err(err),
                     }
                 });
             };


### PR DESCRIPTION
The fallback func with no args should return Result<(), Vec<u8>>. It should not be possible to return Result<Vec<u8>, Vec<u8>>. Having an explicit match statement fixes the issue