### PR TITLE
feat: allow pub item in sol interface

### DIFF
--- a/stylus-proc/src/macros/sol_interface.rs
+++ b/stylus-proc/src/macros/sol_interface.rs
@@ -160,7 +160,7 @@ impl From<&syn_solidity::ItemContract> for Interface {
         let mut iface = Self {
             item_struct: parse_quote! {
                 #(#attrs)*
-                struct #name {
+                pub struct #name {
                     pub address: #AlloyAddress,
                 }
             },
@@ -333,7 +333,7 @@ mod tests {
             &visitor.interfaces[0].item_struct,
             &parse_quote! {
                 #[interface_attr]
-                struct IService {
+                pub struct IService {
                     pub address: stylus_sdk::alloy_primitives::Address,
                 }
             },


### PR DESCRIPTION
## Description

Make an external interface generated struct public. Otherwise, it won't be possible to put `sol_interface!` macro declaration into a separate module/file, like it was possible before.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
