### PR TITLE
Correct OpenZeppelin Spelling and Update Data Type for Rust Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For information about deploying Rust smart contracts, see the [Cargo Stylus CLI 
 
 Comprehensive documentation on the Rust SDK can be found [here](https://docs.arbitrum.io/stylus/rust-sdk-guide).
 
-This SDK has been audited in August 2024 at commit [#62bd831](https://github.com/OffchainLabs/stylus-sdk-rs/tree/62bd8318c7f3ab5be954cbc264f85bf2ba3f4b06) by OpenZepplin which can be viewed [here](https://blog.openzeppelin.com/stylus-rust-sdk-audit).
+This SDK has been audited in August 2024 at commit [#62bd831](https://github.com/OffchainLabs/stylus-sdk-rs/tree/62bd8318c7f3ab5be954cbc264f85bf2ba3f4b06) by OpenZeppelin which can be viewed [here](https://blog.openzeppelin.com/stylus-rust-sdk-audit).
 
 ## Feature highlights
 
@@ -42,7 +42,7 @@ use stylus_sdk::{alloy_primitives::U256, prelude::*};
 sol_storage! {
   #[entrypoint]
   pub struct Counter {
-    uint256 number;
+    number: U256;
   }
 }
 


### PR DESCRIPTION
### Fix Typo: Corrected the spelling of OpenZeppelin

**Reason:** The correct name of the widely used smart contract library is OpenZeppelin, not OpenZepplin. This typo has been fixed to align with the official name and ensure consistency in the codebase.

### Data Type Update:

**Change:** Replaced uint256 number; with number: U256;

**Reason:** In Solidity, the data type uint256 is used to declare a 256-bit unsigned integer. However, in Rust (especially in the Stylus SDK), the equivalent data type for handling 256-bit unsigned integers is U256, which is provided by the alloy_primitives library. This change ensures that the code is consistent with Rust conventions and will function correctly when working with the Stylus SDK.