### PR TITLE
[2/5] - Define Initial WasmHost Implementation for Wasm Targets

### DIFF
--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -349,7 +349,7 @@ pub trait AccountAccess {
     /// `keccak("") = c5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470`.
     ///
     /// [`EXT_CODEHASH`]: https://www.evm.codes/#3F
-    fn codehash(&self, account: Address) -> B256;
+    fn code_hash(&self, account: Address) -> B256;
 }
 
 /// Provides the ability to pay for memory growth of a Stylus contract.

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -7,6 +7,10 @@ use alloy_primitives::{Address, B256, U256};
 
 use crate::call::{MutatingCallContext, StaticCallContext};
 
+/// The `wasm` module contains the default implementation of the host trait for all programs
+/// that are built for a WASM target.
+pub mod wasm;
+
 /// The host trait defines methods a Stylus contract can use to interact
 /// with a host environment, such as the EVM. It is a composition
 /// of traits with different access to host values and modifications.

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -165,6 +165,9 @@ pub trait StorageAccess {
     /// will cost less than in the EVM.
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
+    ///
+    /// # Safety
+    /// May alias storage.
     fn storage_load_bytes32(&self, key: U256) -> B256;
     /// Writes a 32-byte value to the permanent storage cache. Stylus's storage format is identical to that
     /// of the EVM. This means that, under the hood, this hostio represents storing a 32-byte value into
@@ -174,7 +177,10 @@ pub trait StorageAccess {
     /// Note: because the value is cached, one must call `storage_flush_cache` to persist it.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    fn storage_cache_bytes32(&self, key: U256, value: B256);
+    ///
+    /// # Safety
+    /// May alias storage.
+    unsafe fn storage_cache_bytes32(&self, key: U256, value: B256);
     /// Persists any dirty values in the storage cache to the EVM state trie, dropping the cache entirely if requested.
     /// Analogous to repeated invocations of [`SSTORE`].
     ///

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -165,9 +165,6 @@ pub trait StorageAccess {
     /// will cost less than in the EVM.
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
-    ///
-    /// # Safety
-    /// May alias storage.
     fn storage_load_bytes32(&self, key: U256) -> B256;
     /// Writes a 32-byte value to the permanent storage cache. Stylus's storage format is identical to that
     /// of the EVM. This means that, under the hood, this hostio represents storing a 32-byte value into

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -81,7 +81,7 @@ pub trait CalldataAccess {
 
 /// Provides access to programmatic creation of contracts via the host environment's CREATE
 /// and CREATE2 opcodes in the EVM.
-pub trait DeploymentAccess {
+pub unsafe trait DeploymentAccess {
     /// Deploys a new contract using the init code provided, which the EVM executes to construct
     /// the code of the newly deployed contract. The init code must be written in EVM bytecode, but
     /// the code it deploys can be that of a Stylus program. The code returned will be treated as
@@ -97,12 +97,13 @@ pub trait DeploymentAccess {
     ///
     /// [`Deploying Stylus Programs`]: https://docs.arbitrum.io/stylus/quickstart
     /// [`CREATE`]: https://www.evm.codes/#f0
-    fn create1(
+    unsafe fn create1(
         &self,
         code: Address,
         endowment: U256,
-        salt: Option<B256>,
-    ) -> Result<Address, Vec<u8>>;
+        contract: &mut Address,
+        revert_data_len: &mut usize,
+    );
     /// Deploys a new contract using the init code provided, which the EVM executes to construct
     /// the code of the newly deployed contract. The init code must be written in EVM bytecode, but
     /// the code it deploys can be that of a Stylus program. The code returned will be treated as
@@ -118,12 +119,14 @@ pub trait DeploymentAccess {
     ///
     /// [`Deploying Stylus Programs`]: https://docs.arbitrum.io/stylus/quickstart
     /// [`CREATE2`]: https://www.evm.codes/#f5
-    fn create2(
+    unsafe fn create2(
         &self,
         code: Address,
         endowment: U256,
-        salt: Option<B256>,
-    ) -> Result<Address, Vec<u8>>;
+        salt: B256,
+        contract: &mut Address,
+        revert_data_len: &mut usize,
+    );
 }
 
 /// Provides access to storage access and mutation via host methods.
@@ -166,7 +169,7 @@ pub trait StorageAccess {
 }
 
 /// Provides access to calling other contracts using host semantics.
-pub trait CallAccess {
+pub unsafe trait CallAccess {
     /// Calls the contract at the given address with options for passing value and to limit the
     /// amount of gas supplied. The return status indicates whether the call succeeded, and is
     /// nonzero on failure.
@@ -181,12 +184,17 @@ pub trait CallAccess {
     /// to send as much as possible.
     ///
     /// [`CALL`]: https://www.evm.codes/#f1
-    fn call_contract(
+    ///
+    /// SAFETY: This method should only be used in advanced cases. For safe calls to contracts,
+    /// instantiate a CallBuilder instead.
+    unsafe fn call_contract(
         &self,
-        context: impl MutatingCallContext,
         to: Address,
         data: &[u8],
-    ) -> Result<Vec<u8>, crate::call::Error>;
+        value: U256,
+        gas: u64,
+        outs_len: &mut usize,
+    ) -> u8;
     /// Static calls the contract at the given address, with the option to limit the amount of gas
     /// supplied. The return status indicates whether the call succeeded, and is nonzero on
     /// failure.
@@ -201,12 +209,16 @@ pub trait CallAccess {
     /// possible.
     ///
     /// [`STATIC_CALL`]: https://www.evm.codes/#FA
-    fn static_call_contract(
+    ///
+    /// SAFETY: This method should only be used in advanced cases. For safe calls to contracts,
+    /// instantiate a CallBuilder instead.
+    unsafe fn static_call_contract(
         &self,
-        context: impl StaticCallContext,
         to: Address,
         data: &[u8],
-    ) -> Result<Vec<u8>, crate::call::Error>;
+        gas: u64,
+        outs_len: &mut usize,
+    ) -> u8;
     /// Delegate calls the contract at the given address, with the option to limit the amount of
     /// gas supplied. The return status indicates whether the call succeeded, and is nonzero on
     /// failure.
@@ -221,12 +233,16 @@ pub trait CallAccess {
     /// possible.
     ///
     /// [`DELEGATE_CALL`]: https://www.evm.codes/#F4
-    fn delegate_call_contract(
+    ///
+    /// SAFETY: This method should only be used in advanced cases. For safe calls to contracts,
+    /// instantiate a CallBuilder instead.
+    unsafe fn delegate_call_contract(
         &self,
-        context: impl MutatingCallContext,
         to: Address,
         data: &[u8],
-    ) -> Result<Vec<u8>, crate::call::Error>;
+        gas: u64,
+        outs_len: &mut usize,
+    ) -> u8;
 }
 
 /// Provides access to host methods relating to the block a transactions

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -31,8 +31,9 @@ pub trait Host:
 
 /// Defines a trait that allows a Stylus contract to access its host safely.
 pub trait HostAccess<H: Host> {
-    /// Provides access to the parametrized host value of a contract.
-    fn get_host(&self) -> &H;
+    /// Provides access to the parametrized host of a contract, giving access
+    /// to all the desired hostios from the user.
+    fn vm(&self) -> H;
 }
 
 /// Provides access to native cryptography extensions provided by

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -5,8 +5,6 @@
 use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, U256};
 
-use crate::call::{MutatingCallContext, StaticCallContext};
-
 /// The `wasm` module contains the default implementation of the host trait for all programs
 /// that are built for a WASM target.
 pub mod wasm;
@@ -81,6 +79,7 @@ pub trait CalldataAccess {
 
 /// Provides access to programmatic creation of contracts via the host environment's CREATE
 /// and CREATE2 opcodes in the EVM.
+///
 pub unsafe trait DeploymentAccess {
     /// Deploys a new contract using the init code provided, which the EVM executes to construct
     /// the code of the newly deployed contract. The init code must be written in EVM bytecode, but

--- a/stylus-sdk/src/host/wasm.rs
+++ b/stylus-sdk/src/host/wasm.rs
@@ -1,0 +1,191 @@
+use crate::{
+    block, call::Call, contract, evm, host::*, hostio, msg, storage::Storage, tx, types::AddressVM,
+};
+
+/// WasmHost is the default implementation of the host trait
+/// for all Stylus programs using the SDK.
+pub struct WasmHost;
+// impl Host for WasmHost {}
+
+// impl CryptographyAccess for WasmHost {
+//     fn native_keccak256(&self, input: &[u8]) -> FixedBytes<32> {
+//         FixedBytes::<32>::default()
+//     }
+// }
+
+impl CalldataAccess for WasmHost {
+    fn read_args(&self, len: usize) -> Vec<u8> {
+        let mut input = Vec::with_capacity(len);
+        unsafe {
+            hostio::read_args(input.as_mut_ptr());
+            input.set_len(len);
+        }
+        input
+    }
+    fn read_return_data(&self, offset: usize, size: Option<usize>) -> Vec<u8> {
+        let size = size.unwrap_or_else(|| self.return_data_size().saturating_sub(offset));
+
+        let mut data = Vec::with_capacity(size);
+        if size > 0 {
+            unsafe {
+                let bytes_written = hostio::read_return_data(data.as_mut_ptr(), offset, size);
+                debug_assert!(bytes_written <= size);
+                data.set_len(bytes_written);
+            }
+        };
+        data
+    }
+    fn return_data_size(&self) -> usize {
+        contract::return_data_len()
+    }
+    fn write_result(&self, data: &[u8]) {
+        unsafe {
+            hostio::write_result(data.as_ptr(), data.len());
+        }
+    }
+}
+
+impl StorageAccess for WasmHost {
+    fn emit_log(&self, input: &[u8], num_topics: usize) {
+        unsafe { hostio::emit_log(input.as_ptr(), input.len(), num_topics) }
+    }
+    // TODO: Make this an unsafe func?
+    fn storage_cache_bytes32(&self, key: U256, value: B256) {
+        unsafe {
+            hostio::storage_cache_bytes32(B256::from(key).as_ptr(), value.as_ptr());
+        }
+    }
+    fn storage_load_bytes32(&self, key: U256) -> B256 {
+        let mut data = B256::ZERO;
+        unsafe { hostio::storage_load_bytes32(B256::from(key).as_ptr(), data.as_mut_ptr()) };
+        data
+    }
+    fn flush_cache(&self, clear: bool) {
+        unsafe { hostio::storage_flush_cache(clear) }
+    }
+}
+
+impl BlockAccess for WasmHost {
+    fn block_basefee(&self) -> U256 {
+        block::basefee()
+    }
+    fn block_coinbase(&self) -> Address {
+        block::coinbase()
+    }
+    fn block_gas_limit(&self) -> u64 {
+        block::gas_limit()
+    }
+    fn block_number(&self) -> u64 {
+        block::number()
+    }
+    fn block_timestamp(&self) -> u64 {
+        block::timestamp()
+    }
+}
+
+// impl DeploymentAccess for WasmHost {
+//     fn create1(&self) {}
+//     fn create2(&self) {}
+// }
+
+// impl StorageAccess for WasmHost {
+//     fn emit_log(&self, input: &[u8]) {}
+//     fn load(&self, key: U256) -> B256 {
+//         let mut data = B256::ZERO;
+//         unsafe { hostio::storage_load_bytes32(B256::from(key).as_ptr(), data.as_mut_ptr()) };
+//         data
+//     }
+//     fn cache(&self, key: U256, value: B256) {
+//         // TODO: This converts the global storage method from unsafe to safe. Should we do this?
+//         unsafe { hostio::storage_cache_bytes32(B256::from(key).as_ptr(), value.as_ptr()) }
+//     }
+//     fn flush_cache(&self, clear: bool) {
+//         unsafe {
+//             hostio::storage_flush_cache(clear);
+//         }
+//     }
+// }
+
+// impl CallAccess for WasmHost {
+//     fn call_contract(&self) {}
+//     fn static_call_contract(&self) {}
+//     fn delegate_call_contract(&self) {}
+// }
+
+// impl BlockAccess for WasmHost {
+//     fn block_basefee(&self) -> U256 {
+//         block::basefee()
+//     }
+//     fn block_coinbase(&self) -> Address {
+//         block::coinbase()
+//     }
+//     fn block_number(&self) -> u64 {
+//         block::number()
+//     }
+//     fn block_timestamp(&self) -> u64 {
+//         block::timestamp()
+//     }
+//     fn block_gas_limit(&self) -> u64 {
+//         block::gas_limit()
+//     }
+// }
+
+// impl ChainAccess for WasmHost {
+//     fn chain_id(&self) -> u64 {
+//         block::chainid()
+//     }
+// }
+
+// impl AccountAccess for WasmHost {
+//     fn balance(&self, account: Address) -> U256 {
+//         account.balance()
+//     }
+//     fn contract_address(&self) -> Address {
+//         contract::address()
+//     }
+//     fn code(&self, account: Address) -> Vec<u8> {
+//         account.code()
+//     }
+//     fn code_size(&self, account: Address) -> usize {
+//         account.code_size()
+//     }
+//     fn codehash(&self, account: Address) -> FixedBytes<32> {
+//         account.code_hash()
+//     }
+// }
+
+// impl MemoryAccess for WasmHost {
+//     fn pay_for_memory_grow(&self, pages: u16) {
+//         evm::pay_for_memory_grow(pages);
+//     }
+// }
+
+// impl MessageAccess for WasmHost {
+//     fn msg_sender(&self) -> Address {
+//         msg::sender()
+//     }
+//     fn msg_reentrant(&self) -> bool {
+//         msg::reentrant()
+//     }
+//     fn msg_value(&self) -> U256 {
+//         msg::value()
+//     }
+//     fn tx_origin(&self) -> Address {
+//         tx::origin()
+//     }
+// }
+
+// impl MeteringAccess for WasmHost {
+//     fn evm_gas_left(&self) -> u64 {
+//         evm::gas_left()
+//     }
+//     fn evm_ink_left(&self) -> u64 {
+//         evm::ink_left()
+//     }
+//     fn tx_gas_price(&self) -> U256 {
+//         tx::gas_price()
+//     }
+//     fn tx_ink_price(&self) -> u32 {
+//         tx::ink_price()
+//     }
+// }

--- a/stylus-sdk/src/host/wasm.rs
+++ b/stylus-sdk/src/host/wasm.rs
@@ -1,3 +1,6 @@
+// Copyright 2025-2026, Offchain Labs, Inc.
+// For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
+
 use crate::{block, contract, evm, host::*, hostio, msg, tx, types::AddressVM};
 
 /// WasmHost is the default implementation of the host trait

--- a/stylus-sdk/src/host/wasm.rs
+++ b/stylus-sdk/src/host/wasm.rs
@@ -89,11 +89,8 @@ impl StorageAccess for WasmHost {
     fn emit_log(&self, input: &[u8], num_topics: usize) {
         unsafe { hostio::emit_log(input.as_ptr(), input.len(), num_topics) }
     }
-    // TODO: Make this an unsafe func?
-    fn storage_cache_bytes32(&self, key: U256, value: B256) {
-        unsafe {
-            hostio::storage_cache_bytes32(B256::from(key).as_ptr(), value.as_ptr());
-        }
+    unsafe fn storage_cache_bytes32(&self, key: U256, value: B256) {
+        hostio::storage_cache_bytes32(B256::from(key).as_ptr(), value.as_ptr());
     }
     fn storage_load_bytes32(&self, key: U256) -> B256 {
         let mut data = B256::ZERO;


### PR DESCRIPTION
## Description

Follow-up from #199, this PR defines a WasmHost implementation of the Host trait defined in #199. This WASM host will be used by Stylus contracts when they are built for a WASM target. Underneath the hood, they still just invoke the current global hostios that are present in the SDK for simplicity. In the future, global hostios will be deprecated, then moved into the WasmHost implementation.
