### PR TITLE
[3/5] - Use a Boxed, Dyn Host Trait for Contract Initialization

### DIFF
--- a/stylus-proc/src/consts.rs
+++ b/stylus-proc/src/consts.rs
@@ -19,6 +19,8 @@ pub const ASSERT_OVERRIDES_FN: ConstIdent = ConstIdent("__stylus_assert_override
 /// function.
 pub const ALLOW_OVERRIDE_FN: ConstIdent = ConstIdent("__stylus_allow_override");
 
+pub const STYLUS_HOST_FIELD: ConstIdent = ConstIdent("__stylus_host");
+
 /// Definition of a constant identifier
 pub struct ConstIdent(&'static str);
 

--- a/stylus-proc/src/lib.rs
+++ b/stylus-proc/src/lib.rs
@@ -41,8 +41,10 @@ mod utils;
 /// Allows a Rust `struct` to be used in persistent storage.
 ///
 /// ```
+/// extern crate alloc;
 /// # use stylus_sdk::storage::{StorageAddress, StorageBool};
 /// # use stylus_proc::storage;
+/// # use stylus_sdk::prelude::*;
 /// #[storage]
 /// pub struct Contract {
 ///    owner: StorageAddress,
@@ -52,7 +54,7 @@ mod utils;
 ///
 ///#[storage]
 ///pub struct SubStruct {
-///    // types implementing the `StorageType` trait.
+///    number: StorageBool,
 ///}
 /// ```
 ///
@@ -88,6 +90,8 @@ pub fn solidity_storage(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// define types using Solidity syntax, which makes this guarantee easier to see.
 ///
 /// ```
+/// extern crate alloc;
+/// # use stylus_sdk::prelude::*;
 /// # use stylus_proc::sol_storage;
 /// sol_storage! {
 ///     pub struct Contract {
@@ -101,7 +105,9 @@ pub fn solidity_storage(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///         mapping(address => uint) balances;  // becomes a StorageMap
 ///         Delegate[] delegates;               // becomes a StorageVec
 ///     }
-/// #     pub struct Delegate {}
+///     pub struct Delegate {
+///         uint256 id;
+///     }
 /// }
 /// ```
 ///
@@ -197,6 +203,7 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
 /// ```
 /// # extern crate alloc;
 /// # use stylus_sdk::call::Call;
+/// # use stylus_sdk::prelude::*;
 /// # use stylus_proc::{entrypoint, public, sol_interface, storage};
 /// sol_interface! {
 ///     interface IMethods {
@@ -207,7 +214,9 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
 ///     }
 /// }
 ///
-/// # #[entrypoint] #[storage] struct Contract {}
+/// #[entrypoint] #[storage] struct Contract {
+///    total: stylus_sdk::storage::StorageU256,
+/// }
 /// #[public]
 /// impl Contract {
 ///     pub fn call_pure(&self, methods: IMethods) -> Result<(), Vec<u8>> {
@@ -293,6 +302,7 @@ pub fn sol_interface(input: TokenStream) -> TokenStream {
 /// lets you do this automatically.
 ///
 /// ```
+/// extern crate alloc;
 /// # use stylus_proc::{Erase, sol_storage};
 /// sol_storage! {
 ///    #[derive(Erase)]
@@ -367,15 +377,16 @@ pub fn derive_solidity_error(input: TokenStream) -> TokenStream {
 /// ```
 /// # extern crate alloc;
 /// # use stylus_proc::{entrypoint, public, sol_storage};
+/// # use stylus_sdk::prelude::*;
 /// sol_storage! {
 ///     #[entrypoint]
 ///     pub struct Contract {
-///         // ...
+///         uint256 number;
 ///     }
 ///
 ///     // only one entrypoint is allowed
 ///     pub struct SubStruct {
-///         // ...
+///         uint256 number;
 ///     }
 /// }
 /// # #[public] impl Contract {}
@@ -391,10 +402,12 @@ pub fn derive_solidity_error(input: TokenStream) -> TokenStream {
 /// wherein the Stylus SDK's macros and storage types are entirely optional.
 ///
 /// ```
+/// extern crate alloc;
 /// # use stylus_sdk::ArbResult;
 /// # use stylus_proc::entrypoint;
+/// # use stylus_sdk::prelude::*;
 /// #[entrypoint]
-/// fn entrypoint(calldata: Vec<u8>) -> ArbResult {
+/// fn entrypoint(calldata: Vec<u8>, _: alloc::boxed::Box<dyn stylus_sdk::host::Host>) -> ArbResult {
 ///     // bytes-in, bytes-out programming
 /// #   Ok(Vec::new())
 /// }
@@ -479,7 +492,8 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// # extern crate alloc;
 /// # use alloy_primitives::Address;
 /// # use stylus_proc::{entrypoint, public, storage};
-/// # #[entrypoint] #[storage] struct Contract { #[borrow] erc20: Erc20 }
+/// # use stylus_sdk::prelude::*;
+/// # #[entrypoint] #[storage] struct Contract { #[borrow] erc20: Erc20, }
 /// # mod msg {
 /// #     use alloy_primitives::Address;
 /// #     pub fn sender() -> Address { Address::ZERO }
@@ -492,7 +506,9 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///         self.erc20.add_balance(msg::sender(), msg::value())
 ///     }
 /// }
-/// # #[storage] struct Erc20;
+/// # #[storage] struct Erc20 {
+/// #    total: stylus_sdk::storage::StorageU256,
+/// # }
 /// # #[public]
 /// # impl Erc20 {
 /// #     pub fn add_balance(&self, sender: Address, value: u32) -> Result<(), Vec<u8>> {
@@ -525,7 +541,8 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 /// # extern crate alloc;
 /// # use alloy_primitives::U256;
 /// # use stylus_proc::{entrypoint, public, storage};
-/// # #[entrypoint] #[storage] struct Token { #[borrow] erc20: Erc20 }
+/// # use stylus_sdk::prelude::*;
+/// # #[entrypoint] #[storage] struct Token { #[borrow] erc20: Erc20, }
 /// #[public]
 /// #[inherit(Erc20)]
 /// impl Token {
@@ -535,7 +552,9 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///     }
 /// }
 ///
-/// # #[storage] struct Erc20;
+/// #[storage] struct Erc20 {
+///    total: stylus_sdk::storage::StorageU256,
+/// }
 /// #[public]
 /// impl Erc20 {
 ///     pub fn balance_of() -> Result<U256, Vec<u8>> {
@@ -569,17 +588,17 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// ```
 /// # extern crate alloc;
+/// # use stylus_sdk::prelude::*;
 /// # use stylus_proc::{entrypoint, public, sol_storage};
 /// sol_storage! {
 ///     #[entrypoint]
 ///     pub struct Token {
 ///         #[borrow]
 ///         Erc20 erc20;
-///         // ...
 ///     }
 ///
 ///     pub struct Erc20 {
-///         // ...
+///         uint256 total;
 ///     }
 /// }
 /// # #[public] impl Token {}

--- a/stylus-proc/src/lib.rs
+++ b/stylus-proc/src/lib.rs
@@ -106,7 +106,6 @@ pub fn solidity_storage(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///         Delegate[] delegates;               // becomes a StorageVec
 ///     }
 ///     pub struct Delegate {
-///         uint256 id;
 ///     }
 /// }
 /// ```
@@ -214,9 +213,7 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
 ///     }
 /// }
 ///
-/// #[entrypoint] #[storage] struct Contract {
-///    total: stylus_sdk::storage::StorageU256,
-/// }
+/// #[entrypoint] #[storage] struct Contract {}
 /// #[public]
 /// impl Contract {
 ///     pub fn call_pure(&self, methods: IMethods) -> Result<(), Vec<u8>> {
@@ -381,12 +378,10 @@ pub fn derive_solidity_error(input: TokenStream) -> TokenStream {
 /// sol_storage! {
 ///     #[entrypoint]
 ///     pub struct Contract {
-///         uint256 number;
 ///     }
 ///
 ///     // only one entrypoint is allowed
 ///     pub struct SubStruct {
-///         uint256 number;
 ///     }
 /// }
 /// # #[public] impl Contract {}
@@ -506,9 +501,7 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///         self.erc20.add_balance(msg::sender(), msg::value())
 ///     }
 /// }
-/// # #[storage] struct Erc20 {
-/// #    total: stylus_sdk::storage::StorageU256,
-/// # }
+/// # #[storage] struct Erc20;
 /// # #[public]
 /// # impl Erc20 {
 /// #     pub fn add_balance(&self, sender: Address, value: u32) -> Result<(), Vec<u8>> {
@@ -552,9 +545,7 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///     }
 /// }
 ///
-/// #[storage] struct Erc20 {
-///    total: stylus_sdk::storage::StorageU256,
-/// }
+/// #[storage] struct Erc20;
 /// #[public]
 /// impl Erc20 {
 ///     pub fn balance_of() -> Result<U256, Vec<u8>> {

--- a/stylus-proc/src/macros/derive/erase.rs
+++ b/stylus-proc/src/macros/derive/erase.rs
@@ -5,6 +5,8 @@ use proc_macro::TokenStream;
 use quote::ToTokens;
 use syn::{parse_macro_input, parse_quote};
 
+use crate::consts::STYLUS_HOST_FIELD;
+
 /// Implementation of the [`#[derive(Erase)]`][crate::derive_erase] macro.
 pub fn derive_erase(input: TokenStream) -> TokenStream {
     let node = parse_macro_input!(input as syn::ItemStruct);
@@ -17,13 +19,20 @@ pub fn derive_erase(input: TokenStream) -> TokenStream {
 fn impl_erase(node: &syn::ItemStruct) -> syn::ItemImpl {
     let name = &node.ident;
     let (impl_generics, ty_generics, where_clause) = node.generics.split_for_impl();
-    let fields = node.fields.iter().map(|field| &field.ident);
+    let filtered_fields = node
+        .fields
+        .clone()
+        .into_iter()
+        .filter_map(|field| match field.ident {
+            Some(ident) if ident == STYLUS_HOST_FIELD.as_ident() => None,
+            _ => field.ident,
+        });
 
     parse_quote! {
         impl #impl_generics stylus_sdk::storage::Erase for #name #ty_generics #where_clause {
             fn erase(&mut self) {
                 #(
-                    self.#fields.erase();
+                    self.#filtered_fields.erase();
                 )*
             }
         }

--- a/stylus-proc/src/macros/sol_storage/mod.rs
+++ b/stylus-proc/src/macros/sol_storage/mod.rs
@@ -27,7 +27,7 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
             .map(|SolidityField { attrs, name, ty }| -> syn::Field {
                 parse_quote! {
                     #(#attrs)*
-                    pub #name: #ty,
+                    pub #name: #ty
                 }
             })
             .collect();

--- a/stylus-proc/src/macros/sol_storage/mod.rs
+++ b/stylus-proc/src/macros/sol_storage/mod.rs
@@ -27,7 +27,7 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
             .map(|SolidityField { attrs, name, ty }| -> syn::Field {
                 parse_quote! {
                     #(#attrs)*
-                    pub #name: #ty
+                    pub #name: #ty,
                 }
             })
             .collect();
@@ -36,7 +36,7 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
             #(#attrs)*
             #[stylus_sdk::stylus_proc::storage]
             #vis struct #name #generics {
-                #fields,
+                #fields
             }
         });
     }

--- a/stylus-proc/src/macros/sol_storage/mod.rs
+++ b/stylus-proc/src/macros/sol_storage/mod.rs
@@ -36,7 +36,7 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
             #(#attrs)*
             #[stylus_sdk::stylus_proc::storage]
             #vis struct #name #generics {
-                #fields
+                #fields,
             }
         });
     }

--- a/stylus-proc/src/macros/storage.rs
+++ b/stylus-proc/src/macros/storage.rs
@@ -39,8 +39,8 @@ pub fn storage(
             // Extract the original fields.
             let original_fields = named_fields.named;
             quote! {
-                #original_fields
                 #STYLUS_HOST_FIELD: *const dyn stylus_sdk::host::Host,
+                #original_fields
             }
         }
         syn::Fields::Unnamed(_) => {

--- a/stylus-proc/src/macros/storage.rs
+++ b/stylus-proc/src/macros/storage.rs
@@ -121,8 +121,8 @@ impl Storage {
                     let mut space: usize = 32;
                     let mut slot: usize = 0;
                     let accessor = Self {
-                        #init,
                         #STYLUS_HOST_FIELD: host,
+                        #init
                     };
                     accessor
                 }

--- a/stylus-proc/tests/derive_erase.rs
+++ b/stylus-proc/tests/derive_erase.rs
@@ -1,5 +1,6 @@
 // Copyright 2024, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
+extern crate alloc;
 
 use stylus_proc::{storage, Erase};
 use stylus_sdk::storage::{StorageU256, StorageVec};

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -99,7 +99,7 @@ where
 //    defined, then calls with no input calldata will be routed to the fallback function.
 pub fn router_entrypoint<R, S>(
     input: alloc::vec::Vec<u8>,
-    host: alloc::boxed::Box<dyn crate::host::Host>,
+    host: Box<dyn crate::host::Host>,
 ) -> ArbResult
 where
     R: Router<S>,

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -15,6 +15,7 @@
 //! [prelude]: crate::prelude
 //!
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
 use alloy_primitives::U256;
 use core::borrow::BorrowMut;
@@ -96,12 +97,15 @@ where
 //    if no value is received in the transaction. It is implicitly payable.
 //  - Fallback is called when no other function matches a selector. If a receive function is not
 //    defined, then calls with no input calldata will be routed to the fallback function.
-pub fn router_entrypoint<R, S>(input: alloc::vec::Vec<u8>) -> ArbResult
+pub fn router_entrypoint<R, S>(
+    input: alloc::vec::Vec<u8>,
+    host: alloc::boxed::Box<dyn crate::host::Host>,
+) -> ArbResult
 where
     R: Router<S>,
     S: StorageType + TopLevelStorage + BorrowMut<R::Storage>,
 {
-    let mut storage = unsafe { S::new(U256::ZERO, 0) };
+    let mut storage = unsafe { S::new(U256::ZERO, 0, Box::into_raw(host)) };
 
     if input.is_empty() {
         console!("no calldata provided");

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -99,7 +99,7 @@ where
 //    defined, then calls with no input calldata will be routed to the fallback function.
 pub fn router_entrypoint<R, S>(
     input: alloc::vec::Vec<u8>,
-    host: Box<dyn crate::host::Host>,
+    host: alloc::boxed::Box<dyn crate::host::Host>,
 ) -> ArbResult
 where
     R: Router<S>,

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -33,11 +33,9 @@ pub trait Host:
 
 /// Defines a trait that allows a Stylus contract to access its host safely.
 pub trait HostAccess {
-    /// The associated host type for a Stylus contract.
-    type Host: Host;
     /// Provides access to the parametrized host of a contract, giving access
     /// to all the desired hostios from the user.
-    fn vm(&self) -> &Self::Host;
+    fn vm(&self) -> alloc::boxed::Box<dyn crate::host::Host>;
 }
 
 /// Provides access to native cryptography extensions provided by

--- a/stylus-sdk/src/prelude.rs
+++ b/stylus-sdk/src/prelude.rs
@@ -9,6 +9,7 @@
 //! use stylus_sdk::prelude::*;
 //! ```
 
+pub use crate::host::*;
 pub use crate::storage::{Erase, SimpleStorageType, StorageType, TopLevelStorage};
 pub use crate::stylus_proc::*;
 pub use crate::types::AddressVM;

--- a/stylus-sdk/src/storage/bytes.rs
+++ b/stylus-sdk/src/storage/bytes.rs
@@ -60,7 +60,7 @@ impl StorageBytes {
 
     /// Gets the number of bytes stored.
     pub fn len(&self) -> usize {
-        let word = Storage::get_word(self.vm().as_ref(), self.root);
+        let word = Storage::get_word(&self.vm(), self.root);
 
         // check if the data is short
         let slot: &[u8] = word.as_ref();
@@ -89,15 +89,15 @@ impl StorageBytes {
 
         // if shrinking, pull data in
         if (len < 32) && (old > 32) {
-            let word = Storage::get_word(self.vm().as_ref(), *self.base());
-            Storage::set_word(self.vm().as_ref(), self.root, word);
+            let word = Storage::get_word(&self.vm(), *self.base());
+            Storage::set_word(&self.vm(), self.root, word);
             return self.write_len(len);
         }
 
         // if growing, push data out
-        let mut word = Storage::get_word(self.vm().as_ref(), self.root);
+        let mut word = Storage::get_word(&self.vm(), self.root);
         word[31] = 0; // clear len byte
-        Storage::set_word(self.vm().as_ref(), *self.base(), word);
+        Storage::set_word(&self.vm(), *self.base(), word);
         self.write_len(len)
     }
 
@@ -105,14 +105,10 @@ impl StorageBytes {
     unsafe fn write_len(&mut self, len: usize) {
         if len < 32 {
             // place the len in the last byte of the root with the long bit low
-            Storage::set_uint(self.vm().as_ref(), self.root, 31, U8::from(len * 2));
+            Storage::set_uint(&self.vm(), self.root, 31, U8::from(len * 2));
         } else {
             // place the len in the root with the long bit high
-            Storage::set_word(
-                self.vm().as_ref(),
-                self.root,
-                U256::from(len * 2 + 1).into(),
-            )
+            Storage::set_word(&self.vm(), self.root, U256::from(len * 2 + 1).into())
         }
     }
 
@@ -124,7 +120,7 @@ impl StorageBytes {
         macro_rules! assign {
             ($slot:expr) => {
                 unsafe {
-                    Storage::set_uint(self.vm().as_ref(), $slot, index % 32, value); // pack value
+                    Storage::set_uint(&self.vm(), $slot, index % 32, value); // pack value
                     self.write_len(index + 1);
                 }
             };
@@ -137,8 +133,8 @@ impl StorageBytes {
         // convert to multi-word representation
         if index == 31 {
             // copy content over (len byte will be overwritten)
-            let word = Storage::get_word(self.vm().as_ref(), self.root);
-            unsafe { Storage::set_word(self.vm().as_ref(), *self.base(), word) };
+            let word = Storage::get_word(&self.vm(), self.root);
+            unsafe { Storage::set_word(&self.vm(), *self.base(), word) };
         }
 
         let slot = self.base() + U256::from(index / 32);
@@ -158,13 +154,13 @@ impl StorageBytes {
         let clean = index % 32 == 0;
         let byte = self.get(index)?;
 
-        let clear = |slot| unsafe { Storage::clear_word(self.vm().as_ref(), slot) };
+        let clear = |slot| unsafe { Storage::clear_word(&self.vm(), slot) };
 
         // convert to single-word representation
         if len == 32 {
             // copy content over
-            let word = Storage::get_word(self.vm().as_ref(), *self.base());
-            unsafe { Storage::set_word(self.vm().as_ref(), self.root, word) };
+            let word = Storage::get_word(&self.vm(), *self.base());
+            unsafe { Storage::set_word(&self.vm(), self.root, word) };
             clear(*self.base());
         }
 
@@ -175,7 +171,7 @@ impl StorageBytes {
 
         // clear the value
         if len < 32 {
-            unsafe { Storage::set_byte(self.vm().as_ref(), self.root, index, 0) };
+            unsafe { Storage::set_byte(&self.vm(), self.root, index, 0) };
         }
 
         // set the new length
@@ -210,7 +206,7 @@ impl StorageBytes {
     /// UB if index is out of bounds.
     pub unsafe fn get_unchecked(&self, index: usize) -> u8 {
         let (slot, offset) = self.index_slot(index);
-        unsafe { Storage::get_byte(self.vm().as_ref(), slot, offset.into()) }
+        unsafe { Storage::get_byte(&self.vm(), slot, offset.into()) }
     }
 
     /// Gets the full contents of the collection.
@@ -253,11 +249,11 @@ impl Erase for StorageBytes {
         if len > 31 {
             while len > 0 {
                 let slot = self.index_slot(len as usize - 1).0;
-                unsafe { Storage::clear_word(self.vm().as_ref(), slot) };
+                unsafe { Storage::clear_word(&self.vm(), slot) };
                 len -= 32;
             }
         }
-        unsafe { Storage::clear_word(self.vm().as_ref(), self.root) };
+        unsafe { Storage::clear_word(&self.vm(), self.root) };
     }
 }
 

--- a/stylus-sdk/src/storage/bytes.rs
+++ b/stylus-sdk/src/storage/bytes.rs
@@ -2,7 +2,8 @@
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
 
 use super::{Erase, GlobalStorage, Storage, StorageB8, StorageGuard, StorageGuardMut, StorageType};
-use crate::crypto;
+use crate::{crypto, host::HostAccess};
+use alloc::boxed::Box;
 use alloc::{
     string::{String, ToString},
     vec::Vec,
@@ -14,6 +15,7 @@ use core::cell::OnceCell;
 pub struct StorageBytes {
     root: U256,
     base: OnceCell<U256>,
+    __stylus_host: *const dyn crate::host::Host,
 }
 
 impl StorageType for StorageBytes {
@@ -26,11 +28,12 @@ impl StorageType for StorageBytes {
     where
         Self: 'a;
 
-    unsafe fn new(root: U256, offset: u8) -> Self {
+    unsafe fn new(root: U256, offset: u8, host: *const dyn crate::host::Host) -> Self {
         debug_assert!(offset == 0);
         Self {
             root,
             base: OnceCell::new(),
+            __stylus_host: host,
         }
     }
 
@@ -43,6 +46,12 @@ impl StorageType for StorageBytes {
     }
 }
 
+impl HostAccess for StorageBytes {
+    fn vm(&self) -> alloc::boxed::Box<dyn crate::host::Host> {
+        unsafe { alloc::boxed::Box::from_raw(self.__stylus_host as *mut dyn crate::host::Host) }
+    }
+}
+
 impl StorageBytes {
     /// Returns `true` if the collection contains no elements.
     pub fn is_empty(&self) -> bool {
@@ -51,7 +60,7 @@ impl StorageBytes {
 
     /// Gets the number of bytes stored.
     pub fn len(&self) -> usize {
-        let word = Storage::get_word(self.root);
+        let word = Storage::get_word(&self.vm(), self.root);
 
         // check if the data is short
         let slot: &[u8] = word.as_ref();
@@ -80,15 +89,15 @@ impl StorageBytes {
 
         // if shrinking, pull data in
         if (len < 32) && (old > 32) {
-            let word = Storage::get_word(*self.base());
-            Storage::set_word(self.root, word);
+            let word = Storage::get_word(&self.vm(), *self.base());
+            Storage::set_word(&self.vm(), self.root, word);
             return self.write_len(len);
         }
 
         // if growing, push data out
-        let mut word = Storage::get_word(self.root);
+        let mut word = Storage::get_word(&self.vm(), self.root);
         word[31] = 0; // clear len byte
-        Storage::set_word(*self.base(), word);
+        Storage::set_word(&self.vm(), *self.base(), word);
         self.write_len(len)
     }
 
@@ -96,10 +105,10 @@ impl StorageBytes {
     unsafe fn write_len(&mut self, len: usize) {
         if len < 32 {
             // place the len in the last byte of the root with the long bit low
-            Storage::set_uint(self.root, 31, U8::from(len * 2));
+            Storage::set_uint(&self.vm(), self.root, 31, U8::from(len * 2));
         } else {
             // place the len in the root with the long bit high
-            Storage::set_word(self.root, U256::from(len * 2 + 1).into())
+            Storage::set_word(&self.vm(), self.root, U256::from(len * 2 + 1).into())
         }
     }
 
@@ -111,7 +120,7 @@ impl StorageBytes {
         macro_rules! assign {
             ($slot:expr) => {
                 unsafe {
-                    Storage::set_uint($slot, index % 32, value); // pack value
+                    Storage::set_uint(&self.vm(), $slot, index % 32, value); // pack value
                     self.write_len(index + 1);
                 }
             };
@@ -124,8 +133,8 @@ impl StorageBytes {
         // convert to multi-word representation
         if index == 31 {
             // copy content over (len byte will be overwritten)
-            let word = Storage::get_word(self.root);
-            unsafe { Storage::set_word(*self.base(), word) };
+            let word = Storage::get_word(&self.vm(), self.root);
+            unsafe { Storage::set_word(&self.vm(), *self.base(), word) };
         }
 
         let slot = self.base() + U256::from(index / 32);
@@ -145,13 +154,13 @@ impl StorageBytes {
         let clean = index % 32 == 0;
         let byte = self.get(index)?;
 
-        let clear = |slot| unsafe { Storage::clear_word(slot) };
+        let clear = |slot| unsafe { Storage::clear_word(&self.vm(), slot) };
 
         // convert to single-word representation
         if len == 32 {
             // copy content over
-            let word = Storage::get_word(*self.base());
-            unsafe { Storage::set_word(self.root, word) };
+            let word = Storage::get_word(&self.vm(), *self.base());
+            unsafe { Storage::set_word(&self.vm(), self.root, word) };
             clear(*self.base());
         }
 
@@ -162,7 +171,7 @@ impl StorageBytes {
 
         // clear the value
         if len < 32 {
-            unsafe { Storage::set_byte(self.root, index, 0) };
+            unsafe { Storage::set_byte(&self.vm(), self.root, index, 0) };
         }
 
         // set the new length
@@ -186,7 +195,7 @@ impl StorageBytes {
             return None;
         }
         let (slot, offset) = self.index_slot(index);
-        let value = unsafe { StorageB8::new(slot, offset) };
+        let value = unsafe { StorageB8::new(slot, offset, Box::into_raw(self.vm())) };
         Some(StorageGuardMut::new(value))
     }
 
@@ -197,7 +206,7 @@ impl StorageBytes {
     /// UB if index is out of bounds.
     pub unsafe fn get_unchecked(&self, index: usize) -> u8 {
         let (slot, offset) = self.index_slot(index);
-        unsafe { Storage::get_byte(slot, offset.into()) }
+        unsafe { Storage::get_byte(&self.vm(), slot, offset.into()) }
     }
 
     /// Gets the full contents of the collection.
@@ -240,11 +249,11 @@ impl Erase for StorageBytes {
         if len > 31 {
             while len > 0 {
                 let slot = self.index_slot(len as usize - 1).0;
-                unsafe { Storage::clear_word(slot) };
+                unsafe { Storage::clear_word(&self.vm(), slot) };
                 len -= 32;
             }
         }
-        unsafe { Storage::clear_word(self.root) };
+        unsafe { Storage::clear_word(&self.vm(), self.root) };
     }
 }
 
@@ -277,8 +286,8 @@ impl StorageType for StorageString {
     where
         Self: 'a;
 
-    unsafe fn new(slot: U256, offset: u8) -> Self {
-        Self(StorageBytes::new(slot, offset))
+    unsafe fn new(slot: U256, offset: u8, host: *const dyn crate::host::Host) -> Self {
+        Self(StorageBytes::new(slot, offset, host))
     }
 
     fn load<'s>(self) -> Self::Wraps<'s> {

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -26,7 +26,6 @@ use crate::{
     host::{Host, HostAccess},
     hostio,
 };
-use alloc::boxed::Box;
 use alloy_primitives::{Address, BlockHash, BlockNumber, FixedBytes, Signed, Uint, B256, U256};
 use alloy_sol_types::sol_data::{ByteCount, IntBitCount, SupportedFixedBytes, SupportedInt};
 use core::{cell::OnceCell, marker::PhantomData, ops::Deref};

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -54,7 +54,7 @@ pub struct StorageCache;
 
 impl GlobalStorage for StorageCache {
     /// Retrieves a 32-byte EVM word from persistent storage.
-    fn get_word(host: &dyn crate::host::Host, key: U256) -> B256 {
+    fn get_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256) -> B256 {
         host.storage_load_bytes32(key)
     }
 
@@ -63,7 +63,7 @@ impl GlobalStorage for StorageCache {
     /// # Safety
     ///
     /// May alias storage.
-    unsafe fn set_word(host: &dyn crate::host::Host, key: U256, value: B256) {
+    unsafe fn set_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256, value: B256) {
         host.storage_cache_bytes32(key, value)
     }
 }
@@ -173,7 +173,7 @@ where
     /// Sets the underlying [`alloy_primitives::Uint`] in persistent storage.
     pub fn set(&mut self, value: Uint<B, L>) {
         overwrite_cell(&mut self.cached, value);
-        unsafe { Storage::set_uint(self.vm().as_ref(), self.slot, self.offset.into(), value) };
+        unsafe { Storage::set_uint(&self.vm(), self.slot, self.offset.into(), value) };
     }
 }
 
@@ -230,9 +230,8 @@ where
     type Target = Uint<B, L>;
 
     fn deref(&self) -> &Self::Target {
-        self.cached.get_or_init(|| unsafe {
-            Storage::get_uint(self.vm().as_ref(), self.slot, self.offset.into())
-        })
+        self.cached
+            .get_or_init(|| unsafe { Storage::get_uint(&self.vm(), self.slot, self.offset.into()) })
     }
 }
 
@@ -282,7 +281,7 @@ where
     /// Gets the underlying [`Signed`] in persistent storage.
     pub fn set(&mut self, value: Signed<B, L>) {
         overwrite_cell(&mut self.cached, value);
-        unsafe { Storage::set_signed(self.vm().as_ref(), self.slot, self.offset.into(), value) };
+        unsafe { Storage::set_signed(&self.vm(), self.slot, self.offset.into(), value) };
     }
 }
 
@@ -339,7 +338,7 @@ where
 
     fn deref(&self) -> &Self::Target {
         self.cached.get_or_init(|| unsafe {
-            Storage::get_signed(self.vm().as_ref(), self.slot, self.offset.into())
+            Storage::get_signed(&self.vm(), self.slot, self.offset.into())
         })
     }
 }
@@ -377,7 +376,7 @@ impl<const N: usize> StorageFixedBytes<N> {
     /// Gets the underlying [`FixedBytes`] in persistent storage.
     pub fn set(&mut self, value: FixedBytes<N>) {
         overwrite_cell(&mut self.cached, value);
-        unsafe { Storage::set(self.vm().as_ref(), self.slot, self.offset.into(), value) }
+        unsafe { Storage::set(&self.vm(), self.slot, self.offset.into(), value) }
     }
 }
 
@@ -430,9 +429,8 @@ impl<const N: usize> Deref for StorageFixedBytes<N> {
     type Target = FixedBytes<N>;
 
     fn deref(&self) -> &Self::Target {
-        self.cached.get_or_init(|| unsafe {
-            Storage::get(self.vm().as_ref(), self.slot, self.offset.into())
-        })
+        self.cached
+            .get_or_init(|| unsafe { Storage::get(&self.vm(), self.slot, self.offset.into()) })
     }
 }
 
@@ -466,14 +464,7 @@ impl StorageBool {
     /// Gets the underlying [`bool`] in persistent storage.
     pub fn set(&mut self, value: bool) {
         overwrite_cell(&mut self.cached, value);
-        unsafe {
-            Storage::set_byte(
-                self.vm().as_ref(),
-                self.slot,
-                self.offset.into(),
-                value as u8,
-            )
-        }
+        unsafe { Storage::set_byte(&self.vm(), self.slot, self.offset.into(), value as u8) }
     }
 }
 
@@ -518,7 +509,7 @@ impl Deref for StorageBool {
 
     fn deref(&self) -> &Self::Target {
         self.cached.get_or_init(|| unsafe {
-            let data = Storage::get_byte(self.vm().as_ref(), self.slot, self.offset.into());
+            let data = Storage::get_byte(&self.vm(), self.slot, self.offset.into());
             data != 0
         })
     }
@@ -554,14 +545,7 @@ impl StorageAddress {
     /// Gets the underlying [`Address`] in persistent storage.
     pub fn set(&mut self, value: Address) {
         overwrite_cell(&mut self.cached, value);
-        unsafe {
-            Storage::set::<20>(
-                self.vm().as_ref(),
-                self.slot,
-                self.offset.into(),
-                value.into(),
-            )
-        }
+        unsafe { Storage::set::<20>(&self.vm(), self.slot, self.offset.into(), value.into()) }
     }
 }
 
@@ -606,7 +590,7 @@ impl Deref for StorageAddress {
 
     fn deref(&self) -> &Self::Target {
         self.cached.get_or_init(|| unsafe {
-            Storage::get::<20>(self.vm().as_ref(), self.slot, self.offset.into()).into()
+            Storage::get::<20>(&self.vm(), self.slot, self.offset.into()).into()
         })
     }
 }
@@ -645,7 +629,7 @@ impl StorageBlockNumber {
     pub fn set(&mut self, value: BlockNumber) {
         overwrite_cell(&mut self.cached, value);
         let value = FixedBytes::from(value.to_be_bytes());
-        unsafe { Storage::set::<8>(self.vm().as_ref(), self.slot, self.offset.into(), value) };
+        unsafe { Storage::set::<8>(&self.vm(), self.slot, self.offset.into(), value) };
     }
 }
 
@@ -690,7 +674,7 @@ impl Deref for StorageBlockNumber {
 
     fn deref(&self) -> &Self::Target {
         self.cached.get_or_init(|| unsafe {
-            let data = Storage::get::<8>(self.vm().as_ref(), self.slot, self.offset.into());
+            let data = Storage::get::<8>(&self.vm(), self.slot, self.offset.into());
             u64::from_be_bytes(data.0)
         })
     }
@@ -728,7 +712,7 @@ impl StorageBlockHash {
     /// Sets the underlying [`BlockHash`] in persistent storage.
     pub fn set(&mut self, value: BlockHash) {
         overwrite_cell(&mut self.cached, value);
-        unsafe { Storage::set_word(self.vm().as_ref(), self.slot, value) }
+        unsafe { Storage::set_word(&self.vm(), self.slot, value) }
     }
 }
 
@@ -771,7 +755,7 @@ impl Deref for StorageBlockHash {
 
     fn deref(&self) -> &Self::Target {
         self.cached
-            .get_or_init(|| Storage::get_word(self.vm().as_ref(), self.slot))
+            .get_or_init(|| Storage::get_word(&self.vm(), self.slot))
     }
 }
 

--- a/stylus-sdk/src/storage/traits.rs
+++ b/stylus-sdk/src/storage/traits.rs
@@ -189,7 +189,7 @@ pub trait GlobalStorage {
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
     unsafe fn get<const N: usize>(
-        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        host: &dyn crate::host::Host,
         key: U256,
         offset: usize,
     ) -> FixedBytes<N> {
@@ -211,7 +211,7 @@ pub trait GlobalStorage {
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
     unsafe fn get_uint<const B: usize, const L: usize>(
-        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        host: &dyn crate::host::Host,
         key: U256,
         offset: usize,
     ) -> Uint<B, L> {
@@ -233,7 +233,7 @@ pub trait GlobalStorage {
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
     unsafe fn get_signed<const B: usize, const L: usize>(
-        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        host: &dyn crate::host::Host,
         key: U256,
         offset: usize,
     ) -> Signed<B, L> {
@@ -250,11 +250,7 @@ pub trait GlobalStorage {
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    unsafe fn get_byte(
-        host: &alloc::boxed::Box<dyn crate::host::Host>,
-        key: U256,
-        offset: usize,
-    ) -> u8 {
+    unsafe fn get_byte(host: &dyn crate::host::Host, key: U256, offset: usize) -> u8 {
         debug_assert!(offset <= 32);
         let word = Self::get::<1>(host, key, offset);
         word[0]
@@ -271,7 +267,7 @@ pub trait GlobalStorage {
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    fn get_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256) -> B256;
+    fn get_word(host: &dyn crate::host::Host, key: U256) -> B256;
 
     /// Writes `N ≤ 32` bytes to persistent storage, performing [`SSTORE`]'s only as needed.
     /// The bytes are written to slot `key`, starting `offset` bytes from the left.
@@ -284,7 +280,7 @@ pub trait GlobalStorage {
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
     unsafe fn set<const N: usize>(
-        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        host: &dyn crate::host::Host,
         key: U256,
         offset: usize,
         value: FixedBytes<N>,
@@ -314,7 +310,7 @@ pub trait GlobalStorage {
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
     unsafe fn set_uint<const B: usize, const L: usize>(
-        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        host: &dyn crate::host::Host,
         key: U256,
         offset: usize,
         value: Uint<B, L>,
@@ -349,7 +345,7 @@ pub trait GlobalStorage {
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
     unsafe fn set_signed<const B: usize, const L: usize>(
-        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        host: &dyn crate::host::Host,
         key: U256,
         offset: usize,
         value: Signed<B, L>,
@@ -366,12 +362,7 @@ pub trait GlobalStorage {
     /// Aliases if called during the lifetime an overlapping accessor.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    unsafe fn set_byte(
-        host: &alloc::boxed::Box<dyn crate::host::Host>,
-        key: U256,
-        offset: usize,
-        value: u8,
-    ) {
+    unsafe fn set_byte(host: &dyn crate::host::Host, key: U256, offset: usize, value: u8) {
         let fixed = FixedBytes::from_slice(&[value]);
         Self::set::<1>(host, key, offset, fixed)
     }
@@ -383,7 +374,7 @@ pub trait GlobalStorage {
     /// Aliases if called during the lifetime an overlapping accessor.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    unsafe fn set_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256, value: B256);
+    unsafe fn set_word(host: &dyn crate::host::Host, key: U256, value: B256);
 
     /// Clears the 32-byte word at the given key, performing [`SSTORE`]'s only as needed.
     ///
@@ -392,7 +383,7 @@ pub trait GlobalStorage {
     /// Aliases if called during the lifetime an overlapping accessor.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    unsafe fn clear_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256) {
+    unsafe fn clear_word(host: &dyn crate::host::Host, key: U256) {
         Self::set_word(host, key, B256::ZERO)
     }
 }

--- a/stylus-sdk/src/storage/traits.rs
+++ b/stylus-sdk/src/storage/traits.rs
@@ -51,7 +51,7 @@ pub trait StorageType: Sized {
     /// Aliases storage if two calls to the same slot and offset occur within the same lifetime.
     ///
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    unsafe fn new(slot: U256, offset: u8) -> Self;
+    unsafe fn new(slot: U256, offset: u8, host: *const dyn crate::host::Host) -> Self;
 
     /// Load the wrapped type, consuming the accessor.
     /// Note: most types have a `get` and/or `getter`, which don't consume `Self`.
@@ -188,9 +188,13 @@ pub trait GlobalStorage {
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    unsafe fn get<const N: usize>(key: U256, offset: usize) -> FixedBytes<N> {
+    unsafe fn get<const N: usize>(
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        key: U256,
+        offset: usize,
+    ) -> FixedBytes<N> {
         debug_assert!(N + offset <= 32);
-        let word = Self::get_word(key);
+        let word = Self::get_word(host, key);
         let value = &word[offset..][..N];
         FixedBytes::from_slice(value)
     }
@@ -206,9 +210,13 @@ pub trait GlobalStorage {
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    unsafe fn get_uint<const B: usize, const L: usize>(key: U256, offset: usize) -> Uint<B, L> {
+    unsafe fn get_uint<const B: usize, const L: usize>(
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        key: U256,
+        offset: usize,
+    ) -> Uint<B, L> {
         debug_assert!(B / 8 + offset <= 32);
-        let word = Self::get_word(key);
+        let word = Self::get_word(host, key);
         let value = &word[offset..][..B / 8];
         Uint::try_from_be_slice(value).unwrap()
     }
@@ -224,8 +232,12 @@ pub trait GlobalStorage {
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    unsafe fn get_signed<const B: usize, const L: usize>(key: U256, offset: usize) -> Signed<B, L> {
-        Signed::from_raw(Self::get_uint(key, offset))
+    unsafe fn get_signed<const B: usize, const L: usize>(
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        key: U256,
+        offset: usize,
+    ) -> Signed<B, L> {
+        Signed::from_raw(Self::get_uint(host, key, offset))
     }
 
     /// Retrieves a [`u8`] from persistent storage, performing [`SLOAD`]'s only as needed.
@@ -238,9 +250,13 @@ pub trait GlobalStorage {
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    unsafe fn get_byte(key: U256, offset: usize) -> u8 {
+    unsafe fn get_byte(
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        key: U256,
+        offset: usize,
+    ) -> u8 {
         debug_assert!(offset <= 32);
-        let word = Self::get::<1>(key, offset);
+        let word = Self::get::<1>(host, key, offset);
         word[0]
     }
 
@@ -255,7 +271,7 @@ pub trait GlobalStorage {
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    fn get_word(key: U256) -> B256;
+    fn get_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256) -> B256;
 
     /// Writes `N ≤ 32` bytes to persistent storage, performing [`SSTORE`]'s only as needed.
     /// The bytes are written to slot `key`, starting `offset` bytes from the left.
@@ -267,19 +283,24 @@ pub trait GlobalStorage {
     /// Aliases if called during the lifetime an overlapping accessor.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    unsafe fn set<const N: usize>(key: U256, offset: usize, value: FixedBytes<N>) {
+    unsafe fn set<const N: usize>(
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        key: U256,
+        offset: usize,
+        value: FixedBytes<N>,
+    ) {
         debug_assert!(N + offset <= 32);
 
         if N == 32 {
-            return Self::set_word(key, FixedBytes::from_slice(value.as_slice()));
+            return Self::set_word(host, key, FixedBytes::from_slice(value.as_slice()));
         }
 
-        let mut word = Self::get_word(key);
+        let mut word = Self::get_word(host, key);
 
         let dest = word[offset..].as_mut_ptr();
         ptr::copy(value.as_ptr(), dest, N);
 
-        Self::set_word(key, word);
+        Self::set_word(host, key, word);
     }
 
     /// Writes a [`Uint`] to persistent storage, performing [`SSTORE`]'s only as needed.
@@ -293,6 +314,7 @@ pub trait GlobalStorage {
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
     unsafe fn set_uint<const B: usize, const L: usize>(
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
         key: U256,
         offset: usize,
         value: Uint<B, L>,
@@ -301,15 +323,19 @@ pub trait GlobalStorage {
         debug_assert!(B / 8 + offset <= 32);
 
         if B == 256 {
-            return Self::set_word(key, FixedBytes::from_slice(&value.to_be_bytes::<32>()));
+            return Self::set_word(
+                host,
+                key,
+                FixedBytes::from_slice(&value.to_be_bytes::<32>()),
+            );
         }
 
-        let mut word = Self::get_word(key);
+        let mut word = Self::get_word(host, key);
 
         let value = value.to_be_bytes_vec();
         let dest = word[offset..].as_mut_ptr();
         ptr::copy(value.as_ptr(), dest, B / 8);
-        Self::set_word(key, word);
+        Self::set_word(host, key, word);
     }
 
     /// Writes a [`Signed`] to persistent storage, performing [`SSTORE`]'s only as needed.
@@ -323,11 +349,12 @@ pub trait GlobalStorage {
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
     unsafe fn set_signed<const B: usize, const L: usize>(
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
         key: U256,
         offset: usize,
         value: Signed<B, L>,
     ) {
-        Self::set_uint(key, offset, value.into_raw())
+        Self::set_uint(host, key, offset, value.into_raw())
     }
 
     /// Writes a [`u8`] to persistent storage, performing [`SSTORE`]'s only as needed.
@@ -339,9 +366,14 @@ pub trait GlobalStorage {
     /// Aliases if called during the lifetime an overlapping accessor.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    unsafe fn set_byte(key: U256, offset: usize, value: u8) {
+    unsafe fn set_byte(
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        key: U256,
+        offset: usize,
+        value: u8,
+    ) {
         let fixed = FixedBytes::from_slice(&[value]);
-        Self::set::<1>(key, offset, fixed)
+        Self::set::<1>(host, key, offset, fixed)
     }
 
     /// Stores a 32-byte EVM word to persistent storage, performing [`SSTORE`]'s only as needed.
@@ -351,7 +383,7 @@ pub trait GlobalStorage {
     /// Aliases if called during the lifetime an overlapping accessor.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    unsafe fn set_word(key: U256, value: B256);
+    unsafe fn set_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256, value: B256);
 
     /// Clears the 32-byte word at the given key, performing [`SSTORE`]'s only as needed.
     ///
@@ -360,7 +392,7 @@ pub trait GlobalStorage {
     /// Aliases if called during the lifetime an overlapping accessor.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    unsafe fn clear_word(key: U256) {
-        Self::set_word(key, B256::ZERO)
+    unsafe fn clear_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256) {
+        Self::set_word(host, key, B256::ZERO)
     }
 }

--- a/stylus-sdk/src/storage/traits.rs
+++ b/stylus-sdk/src/storage/traits.rs
@@ -189,7 +189,7 @@ pub trait GlobalStorage {
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
     unsafe fn get<const N: usize>(
-        host: &dyn crate::host::Host,
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
         key: U256,
         offset: usize,
     ) -> FixedBytes<N> {
@@ -211,7 +211,7 @@ pub trait GlobalStorage {
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
     unsafe fn get_uint<const B: usize, const L: usize>(
-        host: &dyn crate::host::Host,
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
         key: U256,
         offset: usize,
     ) -> Uint<B, L> {
@@ -233,7 +233,7 @@ pub trait GlobalStorage {
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
     unsafe fn get_signed<const B: usize, const L: usize>(
-        host: &dyn crate::host::Host,
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
         key: U256,
         offset: usize,
     ) -> Signed<B, L> {
@@ -250,7 +250,11 @@ pub trait GlobalStorage {
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    unsafe fn get_byte(host: &dyn crate::host::Host, key: U256, offset: usize) -> u8 {
+    unsafe fn get_byte(
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        key: U256,
+        offset: usize,
+    ) -> u8 {
         debug_assert!(offset <= 32);
         let word = Self::get::<1>(host, key, offset);
         word[0]
@@ -267,7 +271,7 @@ pub trait GlobalStorage {
     ///
     /// [`SLOAD`]: https://www.evm.codes/#54
     /// [`generic_const_exprs`]: https://github.com/rust-lang/rust/issues/76560
-    fn get_word(host: &dyn crate::host::Host, key: U256) -> B256;
+    fn get_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256) -> B256;
 
     /// Writes `N ≤ 32` bytes to persistent storage, performing [`SSTORE`]'s only as needed.
     /// The bytes are written to slot `key`, starting `offset` bytes from the left.
@@ -280,7 +284,7 @@ pub trait GlobalStorage {
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
     unsafe fn set<const N: usize>(
-        host: &dyn crate::host::Host,
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
         key: U256,
         offset: usize,
         value: FixedBytes<N>,
@@ -310,7 +314,7 @@ pub trait GlobalStorage {
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
     unsafe fn set_uint<const B: usize, const L: usize>(
-        host: &dyn crate::host::Host,
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
         key: U256,
         offset: usize,
         value: Uint<B, L>,
@@ -345,7 +349,7 @@ pub trait GlobalStorage {
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
     unsafe fn set_signed<const B: usize, const L: usize>(
-        host: &dyn crate::host::Host,
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
         key: U256,
         offset: usize,
         value: Signed<B, L>,
@@ -362,7 +366,12 @@ pub trait GlobalStorage {
     /// Aliases if called during the lifetime an overlapping accessor.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    unsafe fn set_byte(host: &dyn crate::host::Host, key: U256, offset: usize, value: u8) {
+    unsafe fn set_byte(
+        host: &alloc::boxed::Box<dyn crate::host::Host>,
+        key: U256,
+        offset: usize,
+        value: u8,
+    ) {
         let fixed = FixedBytes::from_slice(&[value]);
         Self::set::<1>(host, key, offset, fixed)
     }
@@ -374,7 +383,7 @@ pub trait GlobalStorage {
     /// Aliases if called during the lifetime an overlapping accessor.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    unsafe fn set_word(host: &dyn crate::host::Host, key: U256, value: B256);
+    unsafe fn set_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256, value: B256);
 
     /// Clears the 32-byte word at the given key, performing [`SSTORE`]'s only as needed.
     ///
@@ -383,7 +392,7 @@ pub trait GlobalStorage {
     /// Aliases if called during the lifetime an overlapping accessor.
     ///
     /// [`SSTORE`]: https://www.evm.codes/#55
-    unsafe fn clear_word(host: &dyn crate::host::Host, key: U256) {
+    unsafe fn clear_word(host: &alloc::boxed::Box<dyn crate::host::Host>, key: U256) {
         Self::set_word(host, key, B256::ZERO)
     }
 }

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -60,7 +60,7 @@ impl<S: StorageType> StorageVec<S> {
 
     /// Gets the number of elements stored.
     pub fn len(&self) -> usize {
-        let word: U256 = Storage::get_word(&self.vm(), self.slot).into();
+        let word: U256 = Storage::get_word(self.vm().as_ref(), self.slot).into();
         word.try_into().unwrap()
     }
 
@@ -72,7 +72,7 @@ impl<S: StorageType> StorageVec<S> {
     /// or any junk data left over from prior dirty operations.
     /// Note that [`StorageVec`] has unlimited capacity, so all lengths are valid.
     pub unsafe fn set_len(&mut self, len: usize) {
-        Storage::set_word(&self.vm(), self.slot, U256::from(len).into())
+        Storage::set_word(self.vm().as_ref(), self.slot, U256::from(len).into())
     }
 
     /// Gets an accessor to the element at a given index, if it exists.
@@ -225,7 +225,7 @@ impl<'a, S: SimpleStorageType<'a>> StorageVec<S> {
             let slot = self.index_slot(index).0;
             let words = S::REQUIRED_SLOTS.max(1);
             for i in 0..words {
-                unsafe { Storage::clear_word(&self.vm(), slot + U256::from(i)) };
+                unsafe { Storage::clear_word(self.vm().as_ref(), slot + U256::from(i)) };
             }
         }
         Some(value)

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -60,7 +60,7 @@ impl<S: StorageType> StorageVec<S> {
 
     /// Gets the number of elements stored.
     pub fn len(&self) -> usize {
-        let word: U256 = Storage::get_word(self.vm().as_ref(), self.slot).into();
+        let word: U256 = Storage::get_word(&self.vm(), self.slot).into();
         word.try_into().unwrap()
     }
 
@@ -72,7 +72,7 @@ impl<S: StorageType> StorageVec<S> {
     /// or any junk data left over from prior dirty operations.
     /// Note that [`StorageVec`] has unlimited capacity, so all lengths are valid.
     pub unsafe fn set_len(&mut self, len: usize) {
-        Storage::set_word(self.vm().as_ref(), self.slot, U256::from(len).into())
+        Storage::set_word(&self.vm(), self.slot, U256::from(len).into())
     }
 
     /// Gets an accessor to the element at a given index, if it exists.
@@ -225,7 +225,7 @@ impl<'a, S: SimpleStorageType<'a>> StorageVec<S> {
             let slot = self.index_slot(index).0;
             let words = S::REQUIRED_SLOTS.max(1);
             for i in 0..words {
-                unsafe { Storage::clear_word(self.vm().as_ref(), slot + U256::from(i)) };
+                unsafe { Storage::clear_word(&self.vm(), slot + U256::from(i)) };
             }
         }
         Some(value)

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -135,10 +135,13 @@ impl<S: StorageType> StorageVec<S> {
     /// # Example
     ///
     /// ```no_run
+    /// extern crate alloc;
+    /// use alloc::boxed::Box;
     /// use stylus_sdk::storage::{StorageVec, StorageType, StorageU256};
     /// use stylus_sdk::alloy_primitives::U256;
     ///
-    /// let mut vec: StorageVec<StorageVec<StorageU256>> = unsafe { StorageVec::new(U256::ZERO, 0) };
+    /// let host = Box::new(stylus_sdk::host::wasm::WasmHost {});
+    /// let mut vec: StorageVec<StorageVec<StorageU256>> = unsafe { StorageVec::new(U256::ZERO, 0, Box::into_raw(host)) };
     /// let mut inner_vec = vec.grow();
     /// inner_vec.push(U256::from(8));
     ///


### PR DESCRIPTION
## Description

This PR follows https://github.com/OffchainLabs/stylus-sdk-rs/pull/200 by adding a host parameter to the StorageType `new` function, and therefore, to all core storage types and contracts in the Stylus SDK. the Router entrypoint now also requires a host as a parameter.

This PR also modifies the stylus-proc crate to generate code that includes a raw pointer to a host in contracts, and implements the Stylus entrypoint by initializing the default implementation of the host trait, the WasmHost.

This PR adds a __stylus_host: *const H field to all storage types, and the proc macro for top-level storage adds it to contracts.

Hello world remains the same