### PR TITLE
[6/?] - Make Deployment Logic Part of the Host Trait

### DIFF
--- a/stylus-core/src/deploy.rs
+++ b/stylus-core/src/deploy.rs
@@ -1,0 +1,59 @@
+// Copyright 2024-2025, Offchain Labs, Inc.
+// For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
+
+extern crate alloc;
+
+use alloy_primitives::{Address, B256, U256};
+
+/// How to manage the storage cache, if enabled.
+#[allow(unused)]
+#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CachePolicy {
+    #[default]
+    DoNothing,
+    Flush,
+    Clear,
+}
+
+/// Provides the ability to deploy a smart contract with the given code and endowment value,
+/// returning the address of the contract. Implementations must take care to handle
+/// reentrancy and storage aliasing.
+pub trait DeploymentAccess {
+    #[cfg(feature = "reentrant")]
+    /// Returns a contract deployer instance.
+    /// Performs a raw deploy of another contract with the given `endowment` and init `code`.
+    /// Returns the address of the newly deployed contract, or the error data in case of failure.
+    ///
+    /// # Safety
+    ///
+    /// Note that the EVM allows init code to make calls to other contracts, which provides a vector for
+    /// reentrancy. This means that this method may enable storage aliasing if used in the middle of a storage
+    /// reference's lifetime and if reentrancy is allowed.
+    ///
+    /// For extra flexibility, this method does not clear the global storage cache.
+    unsafe fn deploy(
+        &self,
+        code: &[u8],
+        endowment: U256,
+        salt: Option<B256>,
+        cache_policy: CachePolicy,
+    ) -> Result<Address, Vec<u8>>;
+    #[cfg(not(feature = "reentrant"))]
+    /// Returns a contract deployer instance.
+    /// Performs a raw deploy of another contract with the given `endowment` and init `code`.
+    /// Returns the address of the newly deployed contract, or the error data in case of failure.
+    ///
+    /// # Safety
+    ///
+    /// Note that the EVM allows init code to make calls to other contracts, which provides a vector for
+    /// reentrancy. This means that this method may enable storage aliasing if used in the middle of a storage
+    /// reference's lifetime and if reentrancy is allowed.
+    ///
+    /// For extra flexibility, this method does not clear the global storage cache.
+    unsafe fn deploy(
+        &self,
+        code: &[u8],
+        endowment: U256,
+        salt: Option<B256>,
+    ) -> Result<Address, Vec<u8>>;
+}

--- a/stylus-core/src/host.rs
+++ b/stylus-core/src/host.rs
@@ -1,9 +1,13 @@
 // Copyright 2024-2025, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
+
 //! Defines host environment methods Stylus SDK contracts have access to.
 extern crate alloc;
 
-use crate::calls::{CallAccess, ValueTransfer};
+use crate::{
+    calls::{CallAccess, ValueTransfer},
+    deploy::DeploymentAccess,
+};
 use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, U256};
 
@@ -17,7 +21,7 @@ use alloy_primitives::{Address, B256, U256};
 pub trait Host:
     CryptographyAccess
     + CalldataAccess
-    + DeploymentAccess
+    + UnsafeDeploymentAccess
     + StorageAccess
     + UnsafeCallAccess
     + BlockAccess
@@ -27,6 +31,7 @@ pub trait Host:
     + MessageAccess
     + MeteringAccess
     + CallAccess
+    + DeploymentAccess
     + ValueTransfer
 {
 }
@@ -85,7 +90,7 @@ pub trait CalldataAccess {
 /// to create1 and create2 opcodes is needed. Using the methods by themselves will not protect
 /// against reentrancy safety, storage aliasing, or cache flushing. For safe contract deployment,
 /// utilize a [`RawDeploy`] struct instead.
-pub unsafe trait DeploymentAccess {
+pub unsafe trait UnsafeDeploymentAccess {
     /// Deploys a new contract using the init code provided, which the EVM executes to construct
     /// the code of the newly deployed contract. The init code must be written in EVM bytecode, but
     /// the code it deploys can be that of a Stylus program. The code returned will be treated as
@@ -108,10 +113,11 @@ pub unsafe trait DeploymentAccess {
     /// utilize a [`RawDeploy`] struct instead for safety.
     unsafe fn create1(
         &self,
-        code: Address,
-        endowment: U256,
-        contract: &mut Address,
-        revert_data_len: &mut usize,
+        code: *const u8,
+        code_len: usize,
+        endowment: *const u8,
+        contract: *mut u8,
+        revert_data_len: *mut usize,
     );
     /// Deploys a new contract using the init code provided, which the EVM executes to construct
     /// the code of the newly deployed contract. The init code must be written in EVM bytecode, but
@@ -135,11 +141,12 @@ pub unsafe trait DeploymentAccess {
     /// utilize a [`RawDeploy`] struct instead for safety.
     unsafe fn create2(
         &self,
-        code: Address,
-        endowment: U256,
-        salt: B256,
-        contract: &mut Address,
-        revert_data_len: &mut usize,
+        code: *const u8,
+        code_len: usize,
+        endowment: *const u8,
+        salt: *const u8,
+        contract: *mut u8,
+        revert_data_len: *mut usize,
     );
 }
 

--- a/stylus-core/src/lib.rs
+++ b/stylus-core/src/lib.rs
@@ -1,7 +1,9 @@
 // Copyright 2024-2025, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
+
 //! Defines host environment methods Stylus SDK contracts have access to.
 pub mod calls;
+pub mod deploy;
 pub mod host;
 pub mod storage;
 

--- a/stylus-sdk/src/host/deploy.rs
+++ b/stylus-sdk/src/host/deploy.rs
@@ -15,6 +15,7 @@ impl DeploymentAccess for WasmVM {
         cache_policy: stylus_core::deploy::CachePolicy,
     ) -> Result<Address, Vec<u8>> {
         use stylus_core::deploy::CachePolicy;
+        use stylus_core::host::StorageAccess;
         match cache_policy {
             CachePolicy::Clear => self.flush_cache(true),
             CachePolicy::Flush => self.flush_cache(false),

--- a/stylus-sdk/src/host/deploy.rs
+++ b/stylus-sdk/src/host/deploy.rs
@@ -1,0 +1,85 @@
+use alloc::vec::Vec;
+use alloy_primitives::{Address, B256, U256};
+use stylus_core::deploy::DeploymentAccess;
+use stylus_core::host::{CalldataAccess, UnsafeDeploymentAccess};
+
+use super::WasmVM;
+
+impl DeploymentAccess for WasmVM {
+    #[cfg(feature = "reentrant")]
+    unsafe fn deploy(
+        &self,
+        code: &[u8],
+        endowment: U256,
+        salt: Option<B256>,
+        cache_policy: stylus_core::deploy::CachePolicy,
+    ) -> Result<Address, Vec<u8>> {
+        use stylus_core::deploy::CachePolicy;
+        match cache_policy {
+            CachePolicy::Clear => self.flush_cache(true),
+            CachePolicy::Flush => self.flush_cache(false),
+            CachePolicy::DoNothing => {}
+        }
+
+        let mut contract = Address::default();
+        let mut revert_data_len: usize = 0;
+
+        let endowment: B256 = endowment.into();
+        if let Some(salt) = salt {
+            self.create2(
+                code.as_ptr(),
+                code.len(),
+                endowment.as_ptr(),
+                salt.as_ptr(),
+                contract.as_mut_ptr(),
+                &mut revert_data_len as *mut _,
+            );
+        } else {
+            self.create1(
+                code.as_ptr(),
+                code.len(),
+                endowment.as_ptr(),
+                contract.as_mut_ptr(),
+                &mut revert_data_len as *mut _,
+            );
+        }
+        if contract.is_zero() {
+            return Err(self.read_return_data(0, None));
+        }
+        Ok(contract)
+    }
+    #[cfg(not(feature = "reentrant"))]
+    unsafe fn deploy(
+        &self,
+        code: &[u8],
+        endowment: U256,
+        salt: Option<B256>,
+    ) -> Result<Address, Vec<u8>> {
+        let mut contract = Address::default();
+        let mut revert_data_len: usize = 0;
+
+        let endowment: B256 = endowment.into();
+        if let Some(salt) = salt {
+            self.create2(
+                code.as_ptr(),
+                code.len(),
+                endowment.as_ptr(),
+                salt.as_ptr(),
+                contract.as_mut_ptr(),
+                &mut revert_data_len as *mut _,
+            );
+        } else {
+            self.create1(
+                code.as_ptr(),
+                code.len(),
+                endowment.as_ptr(),
+                contract.as_mut_ptr(),
+                &mut revert_data_len as *mut _,
+            );
+        }
+        if contract.is_zero() {
+            return Err(self.read_return_data(0, None));
+        }
+        Ok(contract)
+    }
+}

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -7,6 +7,8 @@
 //! of a storage type. Defines two implementations, one when the target arch is wasm32 and the
 //! other when the target is native.
 
+use core::f32::consts::E;
+
 use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, U256};
 
@@ -246,7 +248,7 @@ cfg_if::cfg_if! {
                 context: &dyn MutatingCallContext,
                 to: alloy_primitives::Address,
                 data: &[u8],
-            ) -> Result<Vec<u8>, stylus_core::calls::Error> {
+            ) -> Result<Vec<u8>, stylus_core::calls::errors::Error> {
                 self.0.call(context, to, data)
             }
             #[inline]
@@ -255,7 +257,7 @@ cfg_if::cfg_if! {
                 context: &dyn MutatingCallContext,
                 to: alloy_primitives::Address,
                 data: &[u8],
-            ) -> Result<Vec<u8>, stylus_core::calls::Error> {
+            ) -> Result<Vec<u8>, stylus_core::calls::errors::Error> {
                 self.0.delegate_call(context, to, data)
             }
             #[inline]
@@ -264,7 +266,7 @@ cfg_if::cfg_if! {
                 context: &dyn StaticCallContext,
                 to: alloy_primitives::Address,
                 data: &[u8],
-            ) -> Result<Vec<u8>, stylus_core::calls::Error> {
+            ) -> Result<Vec<u8>, stylus_core::calls::errors::Error> {
                 self.0.static_call(context, to, data)
             }
         }
@@ -298,8 +300,9 @@ cfg_if::cfg_if! {
                 endowment: U256,
                 salt: Option<B256>,
                 cache_policy: CachePolicy,
-            ) -> Result<Address, Vec<u8>>;
-
+            ) -> Result<Address, Vec<u8>> {
+                self.0.deploy(code, endowment, salt, cache_policy)
+            }
             #[inline]
             #[cfg(not(feature = "reentrant"))]
             unsafe fn deploy(
@@ -307,7 +310,9 @@ cfg_if::cfg_if! {
                 code: &[u8],
                 endowment: U256,
                 salt: Option<B256>,
-            ) -> Result<Address, Vec<u8>>;
+            ) -> Result<Address, Vec<u8>> {
+                self.0.deploy(code, endowment, salt)
+            }
         }
     } else {
         /// Defines a struct that provides Stylus contracts access to a host VM

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -18,9 +18,14 @@ use crate::{block, contract, evm, hostio, msg, tx, types::AddressVM};
 /// provides access to cross-contract calls.
 pub mod calls;
 
+/// Defines an implementation of traits for the VM struct
+/// that provide access to programmatic contract deployment.
+pub mod deploy;
+
 cfg_if::cfg_if! {
     if #[cfg(target_arch = "wasm32")] {
         use stylus_core::calls::*;
+        use stylus_core::deploy::*;
 
         /// Defines a struct that provides Stylus contracts access to a host VM
         /// environment via the HostAccessor trait defined in stylus_host.
@@ -55,27 +60,29 @@ cfg_if::cfg_if! {
             }
         }
 
-        unsafe impl DeploymentAccess for VM {
+        unsafe impl UnsafeDeploymentAccess for VM {
             #[inline]
             unsafe fn create1(
                 &self,
-                code: Address,
-                endowment: U256,
-                contract: &mut Address,
-                revert_data_len: &mut usize,
+                code: *const u8,
+                code_len: usize,
+                endowment: *const u8,
+                contract: *mut u8,
+                revert_data_len: *mut usize,
             ) {
-                self.0.create1(code, endowment, contract, revert_data_len)
+                self.0.create1(code, code_len, endowment, contract, revert_data_len)
             }
             #[inline]
             unsafe fn create2(
                 &self,
-                code: Address,
-                endowment: U256,
-                salt: B256,
-                contract: &mut Address,
-                revert_data_len: &mut usize,
+                code: *const u8,
+                code_len: usize,
+                endowment: *const u8,
+                salt: *const u8,
+                contract: *mut u8,
+                revert_data_len: *mut usize,
             ) {
-                self.0.create2(code, endowment, salt, contract, revert_data_len)
+                self.0.create2(code, code_len, endowment, salt, contract, revert_data_len)
             }
         }
 
@@ -263,6 +270,17 @@ cfg_if::cfg_if! {
         }
         impl ValueTransfer for VM {
             #[inline]
+            #[cfg(feature = "reentrant")]
+            fn transfer_eth(
+                &self,
+                storage: &mut dyn stylus_core::storage::TopLevelStorage,
+                to: Address,
+                amount: U256,
+            ) -> Result<(), Vec<u8>> {
+                self.0.transfer_eth(to, storage, amount)
+            }
+            #[inline]
+            #[cfg(not(feature = "reentrant"))]
             fn transfer_eth(
                 &self,
                 to: alloy_primitives::Address,
@@ -270,6 +288,26 @@ cfg_if::cfg_if! {
             ) -> Result<(), Vec<u8>> {
                 self.0.transfer_eth(to, amount)
             }
+        }
+        impl DeploymentAccess for VM {
+            #[inline]
+            #[cfg(feature = "reentrant")]
+            unsafe fn deploy(
+                &self,
+                code: &[u8],
+                endowment: U256,
+                salt: Option<B256>,
+                cache_policy: CachePolicy,
+            ) -> Result<Address, Vec<u8>>;
+
+            #[inline]
+            #[cfg(not(feature = "reentrant"))]
+            unsafe fn deploy(
+                &self,
+                code: &[u8],
+                endowment: U256,
+                salt: Option<B256>,
+            ) -> Result<Address, Vec<u8>>;
         }
     } else {
         /// Defines a struct that provides Stylus contracts access to a host VM
@@ -346,40 +384,27 @@ impl CalldataAccess for WasmVM {
     }
 }
 
-unsafe impl DeploymentAccess for WasmVM {
+unsafe impl UnsafeDeploymentAccess for WasmVM {
     unsafe fn create1(
         &self,
-        code: Address,
-        endowment: U256,
-        contract: &mut Address,
-        revert_data_len: &mut usize,
+        code: *const u8,
+        code_len: usize,
+        endowment: *const u8,
+        contract: *mut u8,
+        revert_data_len: *mut usize,
     ) {
-        let endowment: B256 = endowment.into();
-        hostio::create1(
-            code.as_ptr(),
-            code.len(),
-            endowment.as_ptr(),
-            contract.as_mut_ptr(),
-            revert_data_len as *mut _,
-        );
+        hostio::create1(code, code_len, endowment, contract, revert_data_len);
     }
     unsafe fn create2(
         &self,
-        code: Address,
-        endowment: U256,
-        salt: B256,
-        contract: &mut Address,
-        revert_data_len: &mut usize,
+        code: *const u8,
+        code_len: usize,
+        endowment: *const u8,
+        salt: *const u8,
+        contract: *mut u8,
+        revert_data_len: *mut usize,
     ) {
-        let endowment: B256 = endowment.into();
-        hostio::create2(
-            code.as_ptr(),
-            code.len(),
-            endowment.as_ptr(),
-            salt.as_ptr(),
-            contract.as_mut_ptr(),
-            revert_data_len as *mut _,
-        );
+        hostio::create2(code, code_len, endowment, salt, contract, revert_data_len);
     }
 }
 

--- a/stylus-test/src/mock.rs
+++ b/stylus-test/src/mock.rs
@@ -1,5 +1,6 @@
 use alloy_primitives::{address, Address, B256, U256};
 use calls::{errors::Error, CallAccess, MutatingCallContext, StaticCallContext, ValueTransfer};
+use deploy::DeploymentAccess;
 use std::{cell::RefCell, collections::HashMap};
 
 pub use stylus_core::*;
@@ -97,22 +98,24 @@ impl CalldataAccess for TestVM {
     fn write_result(&self, _data: &[u8]) {}
 }
 
-unsafe impl DeploymentAccess for TestVM {
+unsafe impl UnsafeDeploymentAccess for TestVM {
     unsafe fn create1(
         &self,
-        _code: Address,
-        _endowment: U256,
-        _contract: &mut Address,
-        _revert_data_len: &mut usize,
+        _code: *const u8,
+        _code_len: usize,
+        _endowment: *const u8,
+        _contract: *mut u8,
+        _revert_data_len: *mut usize,
     ) {
     }
     unsafe fn create2(
         &self,
-        _code: Address,
-        _endowment: U256,
-        _salt: B256,
-        _contract: &mut Address,
-        _revert_data_len: &mut usize,
+        _code: *const u8,
+        _code_len: usize,
+        _endowment: *const u8,
+        _salt: *const u8,
+        _contract: *mut u8,
+        _revert_data_len: *mut usize,
     ) {
     }
 }
@@ -313,6 +316,28 @@ impl ValueTransfer for TestVM {
     #[cfg(not(feature = "reentrant"))]
     fn transfer_eth(&self, _to: Address, _amount: U256) -> Result<(), Vec<u8>> {
         Ok(())
+    }
+}
+
+impl DeploymentAccess for TestVM {
+    #[cfg(feature = "reentrant")]
+    unsafe fn deploy(
+        &self,
+        _code: &[u8],
+        _endowment: U256,
+        _salt: Option<B256>,
+        _cache_policy: stylus_core::deploy::CachePolicy,
+    ) -> Result<Address, Vec<u8>> {
+        Ok(Address::ZERO)
+    }
+    #[cfg(not(feature = "reentrant"))]
+    unsafe fn deploy(
+        &self,
+        _code: &[u8],
+        _endowment: U256,
+        _salt: Option<B256>,
+    ) -> Result<Address, Vec<u8>> {
+        Ok(Address::ZERO)
     }
 }
 


### PR DESCRIPTION
## Description

This PR makes the contract deployment logic part of the `Host` trait under a `DeploymentAccess` subtrait. It implements the logic for reentrant and non-reentrant contracts inside of stylus-sdk/host/deploy.rs for the `WasmVM` to be used by Stylus contracts. This is the final part of the SDK that needed to join the `Host` trait, and next PRs can focus on deprecating existing global methods
