### PR TITLE
[8] - Add Missing Methods to Host Trait

### DIFF
--- a/stylus-core/src/lib.rs
+++ b/stylus-core/src/lib.rs
@@ -7,4 +7,20 @@ pub mod deploy;
 pub mod host;
 pub mod storage;
 
+use alloy_sol_types::{abi::token::WordToken, SolEvent, TopicList};
 pub use host::*;
+
+/// Emits a typed, Alloy log.
+pub fn log<T: SolEvent>(vm: &impl Host, event: T) {
+    // According to the alloy docs, encode_topics_raw fails only if the array is too small
+    let mut topics = [WordToken::default(); 4];
+    event.encode_topics_raw(&mut topics).unwrap();
+
+    let count = T::TopicList::COUNT;
+    let mut bytes = Vec::with_capacity(32 * count);
+    for topic in &topics[..count] {
+        bytes.extend_from_slice(topic.as_slice());
+    }
+    event.encode_data_to(&mut bytes);
+    vm.emit_log(&bytes, count);
+}

--- a/stylus-core/src/lib.rs
+++ b/stylus-core/src/lib.rs
@@ -11,7 +11,7 @@ use alloy_sol_types::{abi::token::WordToken, SolEvent, TopicList};
 pub use host::*;
 
 /// Emits a typed, Alloy log.
-pub fn log<T: SolEvent>(vm: &impl Host, event: T) {
+pub fn log<T: SolEvent>(vm: &dyn Host, event: T) {
     // According to the alloy docs, encode_topics_raw fails only if the array is too small
     let mut topics = [WordToken::default(); 4];
     event.encode_topics_raw(&mut topics).unwrap();

--- a/stylus-sdk/src/evm.rs
+++ b/stylus-sdk/src/evm.rs
@@ -47,7 +47,7 @@ pub fn raw_log(topics: &[B256], data: &[u8]) -> Result<(), &'static str> {
 /// Emits a typed alloy log.
 #[deprecated(
     since = "0.8.0",
-    note = "Use the .vm() method available on Stylus contracts instead to access host environment methods"
+    note = "Use the log method available under stylus_sdk::stylus_core::log, or provided by stylus_sdk::prelude::*"
 )]
 pub fn log<T: SolEvent>(event: T) {
     // According to the alloy docs, encode_topics_raw fails only if the array is too small

--- a/stylus-test/src/mock.rs
+++ b/stylus-test/src/mock.rs
@@ -139,7 +139,6 @@ impl StorageAccess for TestVM {
         self.state.borrow_mut().storage.insert(key, value);
     }
 
-    fn emit_log(&self, _input: &[u8], _num_topics: usize) {}
     fn flush_cache(&self, _clear: bool) {}
     fn storage_load_bytes32(&self, key: U256) -> B256 {
         self.state
@@ -356,6 +355,13 @@ impl DeploymentAccess for TestVM {
         _salt: Option<B256>,
     ) -> Result<Address, Vec<u8>> {
         Ok(Address::ZERO)
+    }
+}
+
+impl LogAccess for TestVM {
+    fn emit_log(&self, _input: &[u8], _num_topics: usize) {}
+    fn raw_log(&self, _topics: &[B256], _data: &[u8]) -> Result<(), &'static str> {
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds missing host methods and `gas_to_ink` to the host trait