### PR TITLE
Fix storage bytes set-len when shrinking

### DIFF
--- a/stylus-sdk/src/storage/bytes.rs
+++ b/stylus-sdk/src/storage/bytes.rs
@@ -96,7 +96,7 @@ impl StorageBytes {
         }
 
         // if shrinking, pull data in
-        if (len < 32) && (old > 32) {
+        if (len < 32) && (old >= 32) {
             let word = Storage::get_word(self.__stylus_host.clone(), *self.base());
             Storage::set_word(self.__stylus_host.clone(), self.root, word);
             return self.write_len(len);


### PR DESCRIPTION
When the storage bytes has length 32, it loses data when setting the length to a smaller value because it doesn't move the data correctly.
