### PR TITLE
Add unit tests to storage bytes

### DIFF
--- a/stylus-sdk/src/storage/bytes.rs
+++ b/stylus-sdk/src/storage/bytes.rs
@@ -405,3 +405,508 @@ impl Extend<char> for StorageString {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+    use stylus_test::mock::*;
+
+    #[test]
+    fn test_storage_bytes_is_empty() {
+        let test_vm = TestVM::new();
+        let storage = StorageBytes::from(&test_vm);
+
+        let cases = vec![
+            (B256::ZERO, true),
+            (U256::from(5 * 2).into(), false),
+            (U256::from(500 * 2 + 1).into(), false),
+        ];
+
+        for (value, is_empty) in cases {
+            test_vm.set_storage(U256::ZERO, value);
+            assert_eq!(storage.is_empty(), is_empty);
+        }
+    }
+
+    #[test]
+    fn test_storage_bytes_len() {
+        let test_vm = TestVM::new();
+        let storage = StorageBytes::from(&test_vm);
+
+        let cases = vec![
+            (B256::ZERO, 0),
+            (U256::from(5 * 2).into(), 5),
+            (U256::from(500 * 2 + 1).into(), 500),
+        ];
+
+        for (value, len) in cases {
+            test_vm.set_storage(U256::ZERO, value);
+            assert_eq!(storage.len(), len);
+        }
+    }
+
+    #[test]
+    fn test_storage_bytes_write_len() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let cases = vec![
+            (0, B256::ZERO),
+            (5, U256::from(5 * 2).into()),
+            (500, U256::from(500 * 2 + 1).into()),
+        ];
+
+        for (len, want) in cases {
+            unsafe {
+                storage.write_len(len);
+            }
+            assert_eq!(test_vm.get_storage(U256::ZERO), want);
+        }
+    }
+
+    #[test]
+    fn test_storage_bytes_set_len_small() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let mut value = B256::right_padding_from(&[1, 2, 3, 4, 5]);
+        value[31] = 5 * 2;
+        test_vm.set_storage(U256::ZERO, value);
+
+        unsafe {
+            storage.set_len(4);
+        }
+
+        let mut want = value.clone();
+        want[31] = 4 * 2;
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+    }
+
+    #[test]
+    fn test_storage_bytes_set_len_shrinking() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let value: B256 = U256::from(32 * 2 + 1).into();
+        test_vm.set_storage(U256::ZERO, value);
+
+        let value = B256::from([0xfa; 32]);
+        test_vm.set_storage(*storage.base(), value);
+
+        unsafe {
+            storage.set_len(31);
+        }
+
+        let mut want = B256::from([0xfa; 32]);
+        want[31] = 31 * 2;
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+    }
+
+    #[test]
+    fn test_storage_bytes_set_len_growing() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let mut value = B256::from([0xfa; 32]);
+        value[31] = 31 * 2;
+        test_vm.set_storage(U256::ZERO, value);
+
+        unsafe {
+            storage.set_len(32);
+        }
+
+        let want: B256 = U256::from(32 * 2 + 1).into();
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+        let want = B256::right_padding_from(&[0xfa; 31]);
+        assert_eq!(test_vm.get_storage(*storage.base()), want);
+    }
+
+    #[test]
+    fn test_storage_bytes_push_small() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let mut want = B256::ZERO;
+        for i in 0..31 {
+            storage.push(i);
+            want[i as usize] = i;
+            want[31] = (i + 1) * 2;
+            assert_eq!(test_vm.get_storage(U256::ZERO), want);
+        }
+    }
+
+    #[test]
+    fn test_storage_bytes_push_big() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let value: B256 = U256::from(32 * 2 + 1).into(); // size
+        test_vm.set_storage(U256::ZERO, value);
+        let value = B256::from([0xfa; 32]); // contents
+        test_vm.set_storage(*storage.base(), value);
+
+        storage.push(0xfa);
+
+        let want: B256 = U256::from(33 * 2 + 1).into();
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+        let base = *storage.base();
+        let want = value;
+        assert_eq!(test_vm.get_storage(base), want);
+        let slot = base.saturating_add(U256::from(1));
+        let want = B256::right_padding_from(&[0xfa]);
+        assert_eq!(test_vm.get_storage(slot), want);
+    }
+
+    #[test]
+    fn test_storage_bytes_push_growing() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let mut value = B256::from([0xfa; 32]);
+        value[31] = 31 * 2;
+        test_vm.set_storage(U256::ZERO, value);
+
+        storage.push(0xfa);
+
+        let want: B256 = U256::from(32 * 2 + 1).into();
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+        let want = B256::from([0xfa; 32]);
+        assert_eq!(test_vm.get_storage(*storage.base()), want);
+    }
+
+    #[test]
+    fn test_storage_bytes_pop_small() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let mut data: Vec<u8> = (0..31).collect();
+        data.push(31 * 2);
+        test_vm.set_storage(U256::ZERO, B256::from_slice(&data));
+
+        let mut want = B256::from_slice(&data);
+        for i in (0..31).rev() {
+            let popped = storage.pop();
+            assert_eq!(popped, Some(i));
+            want[i as usize] = 0x0;
+            want[31] = i * 2;
+            assert_eq!(test_vm.get_storage(U256::ZERO), want);
+        }
+
+        let value = storage.pop();
+        assert!(value.is_none());
+        assert_eq!(test_vm.get_storage(U256::ZERO), B256::ZERO);
+    }
+
+    #[test]
+    fn test_storage_bytes_pop_big() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let value: B256 = U256::from(64 * 2 + 1).into();
+        test_vm.set_storage(U256::ZERO, value);
+
+        let data: Vec<u8> = (0..64).collect();
+        let base = *storage.base();
+        let after_base = base.saturating_add(U256::from(1));
+        test_vm.set_storage(base, B256::from_slice(&data[0..32]));
+        test_vm.set_storage(after_base, B256::from_slice(&data[32..64]));
+
+        for i in (32..64).rev() {
+            let popped = storage.pop();
+            assert_eq!(popped, Some(i));
+            let want_size: B256 = U256::from(i * 2 + 1).into();
+            assert_eq!(test_vm.get_storage(U256::ZERO), want_size);
+        }
+
+        assert_eq!(test_vm.get_storage(base), B256::from_slice(&data[0..32]));
+        assert_eq!(test_vm.get_storage(after_base), B256::ZERO);
+    }
+
+    #[test]
+    fn test_storage_bytes_pop_shrinking() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let value: B256 = U256::from(32 * 2 + 1).into();
+        test_vm.set_storage(U256::ZERO, value);
+
+        let data: Vec<u8> = (0..32).collect();
+        let base = *storage.base();
+        test_vm.set_storage(base, B256::from_slice(&data[0..32]));
+
+        let popped = storage.pop();
+        assert_eq!(popped, Some(31));
+
+        assert_eq!(test_vm.get_storage(base), B256::ZERO);
+        let mut want = B256::right_padding_from(&data[0..31]);
+        want[31] = 31 * 2;
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+    }
+
+    #[test]
+    fn test_storage_bytes_get_small() {
+        let test_vm = TestVM::new();
+        let storage = StorageBytes::from(&test_vm);
+
+        let mut value = (0..31).collect::<Vec<u8>>();
+        value.push(31 * 2);
+        test_vm.set_storage(U256::ZERO, B256::from_slice(&value));
+
+        for i in 0..31 {
+            let got = storage.get(i);
+            assert_eq!(got, Some(i));
+        }
+
+        let got = storage.get(31);
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn test_storage_bytes_get_big() {
+        let test_vm = TestVM::new();
+        let storage = StorageBytes::from(&test_vm);
+
+        let value: B256 = U256::from(64 * 2 + 1).into();
+        test_vm.set_storage(U256::ZERO, value);
+
+        let data: Vec<u8> = (0..64).collect();
+        let base = *storage.base();
+        test_vm.set_storage(base, B256::from_slice(&data[0..32]));
+        test_vm.set_storage(
+            base.saturating_add(U256::from(1)),
+            B256::from_slice(&data[32..64]),
+        );
+
+        for i in 0..64 {
+            let got = storage.get(i);
+            assert_eq!(got, Some(i));
+        }
+
+        let got = storage.get(64);
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn test_storage_bytes_get_mut_small() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let mut value = B256::from(&[0xbe; 32]);
+        value[31] = 31 * 2;
+        test_vm.set_storage(U256::ZERO, value);
+
+        let mut want = value;
+        for i in 0..31 {
+            let mut cell = storage.get_mut(i).unwrap();
+            assert_eq!(cell.get(), alloy_primitives::fixed_bytes!("be"));
+            cell.set(alloy_primitives::fixed_bytes!("af"));
+            want[i as usize] = 0xaf;
+            assert_eq!(test_vm.get_storage(U256::ZERO), want);
+        }
+
+        let got = storage.get_mut(31);
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn test_storage_bytes_get_mut_big() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let value: B256 = U256::from(32 * 2 + 1).into();
+        test_vm.set_storage(U256::ZERO, value);
+        let base = *storage.base();
+        let value = B256::from(&[0xbe; 32]);
+        test_vm.set_storage(base, value);
+
+        let mut want = value;
+        for i in 0..32 {
+            let mut cell = storage.get_mut(i).unwrap();
+            assert_eq!(cell.get(), alloy_primitives::fixed_bytes!("be"));
+            cell.set(alloy_primitives::fixed_bytes!("af"));
+            want[i as usize] = 0xaf;
+            assert_eq!(test_vm.get_storage(base), want);
+        }
+
+        let got = storage.get_mut(32);
+        assert!(got.is_none());
+    }
+
+    #[test]
+    fn test_storage_bytes_get_bytes_small() {
+        let test_vm = TestVM::new();
+        let storage = StorageBytes::from(&test_vm);
+
+        let mut value = (0..31).collect::<Vec<u8>>();
+        value.push(31 * 2);
+        test_vm.set_storage(U256::ZERO, B256::from_slice(&value));
+
+        let got = storage.get_bytes();
+        assert_eq!(&got, &value[0..31]);
+    }
+
+    #[test]
+    fn test_storage_bytes_get_bytes_big() {
+        let test_vm = TestVM::new();
+        let storage = StorageBytes::from(&test_vm);
+
+        let value: B256 = U256::from(64 * 2 + 1).into();
+        test_vm.set_storage(U256::ZERO, value);
+
+        let data: Vec<u8> = (0..64).collect();
+        let base = *storage.base();
+        let after_base = base.saturating_add(U256::from(1));
+        test_vm.set_storage(base, B256::from_slice(&data[0..32]));
+        test_vm.set_storage(after_base, B256::from_slice(&data[32..64]));
+
+        let got = storage.get_bytes();
+        assert_eq!(got, data);
+    }
+
+    #[test]
+    fn test_storage_bytes_set_bytes_small() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let value: B256 = U256::from(64 * 2 + 1).into();
+        test_vm.set_storage(U256::ZERO, value);
+
+        let data: Vec<u8> = (0..64).collect();
+        let base = *storage.base();
+        let after_base = base.saturating_add(U256::from(1));
+        test_vm.set_storage(base, B256::from_slice(&data[0..32]));
+        test_vm.set_storage(after_base, B256::from_slice(&data[32..64]));
+
+        let new_data: Vec<u8> = (100..116).collect();
+        storage.set_bytes(&new_data);
+
+        let mut want = B256::right_padding_from(&new_data);
+        want[31] = new_data.len() as u8 * 2;
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+        assert_eq!(test_vm.get_storage(base), B256::ZERO);
+        assert_eq!(test_vm.get_storage(after_base), B256::ZERO);
+    }
+
+    #[test]
+    fn test_storage_bytes_set_bytes_big() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let value: B256 = U256::from(64 * 2 + 1).into();
+        test_vm.set_storage(U256::ZERO, value);
+
+        let data: Vec<u8> = (0..64).collect();
+        let base = *storage.base();
+        let after_base = base.saturating_add(U256::from(1));
+        test_vm.set_storage(base, B256::from_slice(&data[0..32]));
+        test_vm.set_storage(after_base, B256::from_slice(&data[32..64]));
+
+        let new_data: Vec<u8> = (100..132).collect();
+        storage.set_bytes(&new_data);
+
+        let want: B256 = U256::from(32 * 2 + 1).into();
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+        assert_eq!(test_vm.get_storage(base), B256::from_slice(&new_data));
+        assert_eq!(test_vm.get_storage(after_base), B256::ZERO);
+    }
+
+    #[test]
+    fn test_storage_bytes_index_slot_small() {
+        let test_vm = TestVM::new();
+        let storage = StorageBytes::from(&test_vm);
+
+        let cases = vec![(0, U256::ZERO, 0), (1, U256::ZERO, 1), (31, U256::ZERO, 31)];
+
+        for (index, slot, offset) in cases {
+            assert_eq!(storage.index_slot(index), (slot, offset));
+        }
+    }
+
+    #[test]
+    fn test_storage_bytes_index_slot_big() {
+        let test_vm = TestVM::new();
+        let storage = StorageBytes::from(&test_vm);
+
+        let value: B256 = U256::from(32 * 2 + 1).into();
+        test_vm.set_storage(U256::ZERO, value);
+
+        let base = *storage.base();
+        let cases = vec![
+            (0, base, 0),
+            (1, base, 1),
+            (31, base, 31),
+            (32, base.saturating_add(U256::from(1)), 0),
+            (33, base.saturating_add(U256::from(1)), 1),
+            (63, base.saturating_add(U256::from(1)), 31),
+        ];
+
+        for (index, slot, offset) in cases {
+            assert_eq!(storage.index_slot(index), (slot, offset));
+        }
+    }
+
+    #[test]
+    fn test_storage_bytes_base() {
+        let test_vm = TestVM::new();
+        let storage = StorageBytes::from(&test_vm);
+        let want: U256 = crypto::keccak(&[0; 32]).into();
+        assert_eq!(*storage.base(), want);
+    }
+
+    #[test]
+    fn test_storage_bytes_erase() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let size = 300;
+        let value: B256 = U256::from(size * 2 + 1).into();
+        test_vm.set_storage(U256::ZERO, value);
+
+        let n_words = size / 32 + 1;
+        let base = *storage.base();
+        for i in 0..n_words {
+            let word = B256::from([0xfa; 32]);
+            let slot = base.saturating_add(U256::from(i));
+            test_vm.set_storage(slot, word);
+        }
+
+        storage.erase();
+
+        for i in 0..n_words {
+            let slot = base.saturating_add(U256::from(i));
+            assert_eq!(test_vm.get_storage(slot), B256::ZERO);
+        }
+        assert_eq!(test_vm.get_storage(U256::ZERO), B256::ZERO);
+    }
+
+    #[test]
+    fn test_storage_bytes_extend() {
+        let test_vm = TestVM::new();
+        let mut storage = StorageBytes::from(&test_vm);
+
+        let mut data: Vec<u8> = (0..15).collect();
+        storage.extend(&data);
+        let mut want = B256::right_padding_from(&data);
+        want[31] = data.len() as u8 * 2;
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+
+        data.extend(15..30);
+        storage.extend(15..30);
+        let mut want = B256::right_padding_from(&data);
+        want[31] = data.len() as u8 * 2;
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+
+        data.extend(30..45);
+        storage.extend(30..45);
+        let want: B256 = U256::from(data.len() as u8 * 2 + 1).into();
+        assert_eq!(test_vm.get_storage(U256::ZERO), want);
+        let base = *storage.base();
+        assert_eq!(test_vm.get_storage(base), B256::from_slice(&data[0..32]));
+        let after_base = base.saturating_add(U256::from(1));
+        assert_eq!(
+            test_vm.get_storage(after_base),
+            B256::right_padding_from(&data[32..45])
+        );
+    }
+}


### PR DESCRIPTION
Add unit tests to the StorageBytes structure. Theses tests will ensure we don't break StorageBytes when changing the implementation. These changes will be introduced in a following PR.