### PR TITLE
Reduce Wasm Code Size Impact of Host Trait

### DIFF
--- a/stylus-core/src/host.rs
+++ b/stylus-core/src/host.rs
@@ -49,6 +49,12 @@ pub trait HostAccess {
     fn vm(&self) -> &dyn Host;
 }
 
+/// Defines a trait that can deny access to a contract router method if a message value is
+/// passed in while the method is non-payable.
+pub trait ValueDenier {
+    fn deny_value(&self, method_name: &str) -> Result<(), Vec<u8>>;
+}
+
 /// Provides access to native cryptography extensions provided by
 /// a Stylus contract host, such as keccak256.
 pub trait CryptographyAccess {

--- a/stylus-proc/src/macros/public/types.rs
+++ b/stylus-proc/src/macros/public/types.rs
@@ -64,7 +64,7 @@ impl PublicImpl {
         let fallback_deny: Option<syn::ExprIf> = match fallback_purity {
             Purity::Payable => None,
             _ => Some(parse_quote! {
-                if let Err(err) = stylus_sdk::abi::internal::deny_value(storage.vm(), "fallback") {
+                if let Err(err) = storage.deny_value("fallback") {
                     return Some(Err(err));
                 }
             }),
@@ -82,7 +82,7 @@ impl PublicImpl {
         parse_quote! {
             impl<S, #generic_params> #Router<S> for #self_ty
             where
-                S: stylus_sdk::stylus_core::storage::TopLevelStorage + core::borrow::BorrowMut<Self> + stylus_sdk::stylus_core::HostAccess,
+                S: stylus_sdk::stylus_core::storage::TopLevelStorage + core::borrow::BorrowMut<Self> + stylus_sdk::stylus_core::ValueDenier,
                 #(
                     S: core::borrow::BorrowMut<#inheritance>,
                 )*
@@ -320,7 +320,7 @@ impl<E: FnExtension> PublicFn<E> {
         } else {
             let name = self.name.to_string();
             Some(parse_quote! {
-                if let Err(err) = internal::deny_value(storage.vm(), #name) {
+                if let Err(err) = storage.deny_value(#name) {
                     return Some(Err(err));
                 }
             })

--- a/stylus-proc/src/macros/storage.rs
+++ b/stylus-proc/src/macros/storage.rs
@@ -156,6 +156,21 @@ impl Storage {
             }
         }
     }
+    fn impl_value_denier(&self) -> syn::ItemImpl {
+        let name = &self.name;
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+        parse_quote! {
+            impl #impl_generics stylus_sdk::stylus_core::host::ValueDenier for #name #ty_generics #where_clause {
+                fn deny_value(&self, method_name: &str) -> Result<(), Vec<u8>> {
+                    if self.vm().msg_value() == alloy_primitives::U256::ZERO {
+                        return Ok(());
+                    }
+                    // console!("method {method_name} not payable");
+                    Err(vec![])
+                }
+            }
+        }
+    }
     fn impl_from_vm(&self) -> syn::ItemImpl {
         let name = &self.name;
         let (_, ty_generics, where_clause) = self.generics.split_for_impl();
@@ -213,6 +228,7 @@ impl ToTokens for Storage {
         self.item_impl().to_tokens(tokens);
         self.impl_storage_type().to_tokens(tokens);
         self.impl_host_access().to_tokens(tokens);
+        self.impl_value_denier().to_tokens(tokens);
         self.impl_from_vm().to_tokens(tokens);
         for field in &self.fields {
             field.impl_borrow(&self.name).to_tokens(tokens);

--- a/stylus-proc/src/macros/storage.rs
+++ b/stylus-proc/src/macros/storage.rs
@@ -165,7 +165,7 @@ impl Storage {
                     if self.vm().msg_value() == alloy_primitives::U256::ZERO {
                         return Ok(());
                     }
-                    // console!("method {method_name} not payable");
+                    stylus_sdk::console!("method {method_name} not payable");
                     Err(vec![])
                 }
             }

--- a/stylus-proc/tests/derive_erase.rs
+++ b/stylus-proc/tests/derive_erase.rs
@@ -3,6 +3,7 @@
 extern crate alloc;
 
 use stylus_proc::{storage, Erase};
+use stylus_sdk::prelude::*;
 use stylus_sdk::storage::{StorageType, StorageU256, StorageVec};
 
 #[storage]

--- a/stylus-sdk/src/abi/internal.rs
+++ b/stylus-sdk/src/abi/internal.rs
@@ -5,8 +5,7 @@
 //! Most users shouldn't call these.
 
 use crate::{abi::AbiType, console, ArbResult};
-use alloc::{vec, vec::Vec};
-use alloy_primitives::U256;
+use alloc::vec::Vec;
 use alloy_sol_types::SolType;
 use core::fmt;
 
@@ -46,15 +45,6 @@ pub const fn digest_to_selector(digest: [u8; 32]) -> [u8; 4] {
     selector[2] = digest[2];
     selector[3] = digest[3];
     selector
-}
-
-#[allow(unused)]
-pub fn deny_value(vm: &dyn stylus_core::Host, method_name: &str) -> Result<(), Vec<u8>> {
-    if vm.msg_value() == U256::ZERO {
-        return Ok(());
-    }
-    console!("method {method_name} not payable");
-    Err(vec![])
 }
 
 #[allow(unused)]

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -18,7 +18,7 @@
 use alloc::vec::Vec;
 use alloy_primitives::U256;
 use core::borrow::BorrowMut;
-use stylus_core::{storage::TopLevelStorage, HostAccess};
+use stylus_core::{storage::TopLevelStorage, ValueDenier};
 
 use alloy_sol_types::{abi::TokenSeq, private::SolTypeValue, SolType};
 
@@ -46,7 +46,7 @@ pub mod internal;
 /// Composition with other routers is possible via `#[inherit]`.
 pub trait Router<S>
 where
-    S: TopLevelStorage + BorrowMut<Self::Storage> + HostAccess,
+    S: TopLevelStorage + BorrowMut<Self::Storage> + ValueDenier,
 {
     /// The type the [`TopLevelStorage`] borrows into. Usually just `Self`.
     type Storage;
@@ -96,7 +96,7 @@ where
 pub fn router_entrypoint<R, S>(input: alloc::vec::Vec<u8>, host: VM) -> ArbResult
 where
     R: Router<S>,
-    S: StorageType + TopLevelStorage + BorrowMut<R::Storage> + HostAccess,
+    S: StorageType + TopLevelStorage + BorrowMut<R::Storage> + ValueDenier,
 {
     let mut storage = unsafe { S::new(U256::ZERO, 0, host) };
 


### PR DESCRIPTION
## Description

After this PR, the code impact of the `Host` trait addition on contracts is only 0.1Kb compared to the code from 0.7.0.

Using global functions that take in a &dyn Trait has a massive impact on WASM size, compared to instead implementing the method as a trait on your contract. Here’s the context:
We have a Contract struct in Rust, and we have a Router trait we are required to implement. Looks a bit like this today:

![Screenshot 2025-01-31 at 12 09 44](https://github.com/user-attachments/assets/81ca240b-b338-4c88-9c78-1a07a2057f6a)

We route each selector to a specific method of our contract struct, and before that, we check if we need to deny non-payable functions that have a tx with a value
![Screenshot 2025-01-31 at 12 11 23](https://github.com/user-attachments/assets/051ed861-4eb9-4e73-831c-d25fc96a2e35)
The problem is this deny_value method takes in a &dyn Host, which requires the compiler to produce more data to resolve vtables
We fixed this by instead defining a ValueDenier trait that contracts implement, so there is no need for a global deny_value method. Here is 
![Screenshot 2025-01-31 at 12 12 26](https://github.com/user-attachments/assets/0fedbb1d-410e-4d5a-a8a9-cac418c480d9)
the fix, which has 0 impact on wasm size compared to 2Kb from the prior screenshots
