### PR TITLE
Fix Cargo Stylus Replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2899,6 +2899,7 @@ dependencies = [
  "sha3",
  "stylus-core",
  "stylus-proc",
+ "stylus-sdk",
  "stylus-test",
 ]
 

--- a/stylus-proc/Cargo.toml
+++ b/stylus-proc/Cargo.toml
@@ -33,9 +33,10 @@ stylus-sdk.workspace = true
 stylus-core.workspace = true
 
 [features]
-default = []
+default = ["stylus-test"]
 export-abi = ["stylus-sdk/export-abi"]
 reentrant = []
+stylus-test = ["stylus-sdk/stylus-test"]
 
 [package.metadata.docs.rs]
 features = ["export-abi"]

--- a/stylus-proc/src/macros/entrypoint.rs
+++ b/stylus-proc/src/macros/entrypoint.rs
@@ -145,7 +145,7 @@ fn assert_overrides_const(name: &Ident) -> syn::ItemConst {
 
 fn mark_used_fn() -> syn::ItemFn {
     parse_quote! {
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(not(feature = "stylus-test"))]
         #[no_mangle]
         pub unsafe fn mark_used() {
             let host = stylus_sdk::host::VM(stylus_sdk::host::WasmVM{});
@@ -158,7 +158,7 @@ fn mark_used_fn() -> syn::ItemFn {
 fn user_entrypoint_fn(user_fn: Ident) -> syn::ItemFn {
     let deny_reentrant = deny_reentrant();
     parse_quote! {
-        #[cfg(target_arch = "wasm32")]
+        #[cfg(not(feature = "stylus-test"))]
         #[no_mangle]
         pub extern "C" fn user_entrypoint(len: usize) -> usize {
             let host = stylus_sdk::host::VM(stylus_sdk::host::WasmVM{});

--- a/stylus-proc/src/macros/entrypoint.rs
+++ b/stylus-proc/src/macros/entrypoint.rs
@@ -163,7 +163,6 @@ fn user_entrypoint_fn(user_fn: Ident) -> syn::ItemFn {
         pub extern "C" fn user_entrypoint(len: usize) -> usize {
             let host = stylus_sdk::host::VM(stylus_sdk::host::WasmVM{});
             #deny_reentrant
-            host.pay_for_memory_grow(0);
 
             let input = host.read_args(len);
             let (data, status) = match #user_fn(input, host.clone()) {

--- a/stylus-proc/src/macros/storage.rs
+++ b/stylus-proc/src/macros/storage.rs
@@ -144,11 +144,11 @@ impl Storage {
         parse_quote! {
             impl #impl_generics stylus_sdk::stylus_core::HostAccess for #name #ty_generics #where_clause {
                 fn vm(&self) -> &dyn stylus_sdk::stylus_core::Host {
-                    #[cfg(target_arch = "wasm32")]
+                    #[cfg(not(feature = "stylus-test"))]
                     {
                         &self.__stylus_host
                     }
-                    #[cfg(not(target_arch = "wasm32"))]
+                    #[cfg(feature = "stylus-test")]
                     {
                         self.__stylus_host.host.as_ref()
                     }
@@ -204,7 +204,7 @@ impl Storage {
         let (impl_generics, _, _) = new_generics.split_for_impl();
 
         parse_quote! {
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(feature = "stylus-test")]
             impl #impl_generics From<&__StylusHostType> for #name #ty_generics #where_clause {
                 fn from(host: &__StylusHostType) -> Self {
                     unsafe {

--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -19,26 +19,25 @@ derivative.workspace = true
 hex = { workspace = true, default-features = false, features = ["alloc"] }
 keccak-const.workspace = true
 lazy_static.workspace = true
+rclite = { workspace = true, optional = true }
 
 # export-abi
 regex = { workspace = true, optional = true }
 
 # local deps
 mini-alloc = { workspace = true, optional = true }
+stylus-test = { workspace = true, optional = true }
 stylus-proc.workspace = true
 stylus-core.workspace = true
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-stylus-test.workspace = true
 
 [dev-dependencies]
 paste.workspace = true
 sha3.workspace = true
 alloy-primitives = { workspace = true, default-features = false, features=["tiny-keccak"] }
-rclite.workspace = true
+stylus-sdk = { workspace = true, features = ["stylus-test"] }
 
 [package.metadata.docs.rs]
-features = ["default", "docs", "debug", "export-abi"]
+features = ["default", "docs", "debug", "export-abi", "stylus-test"]
 
 [features]
 default = ["mini-alloc", "hostio-caching"]
@@ -47,5 +46,6 @@ debug = []
 docs = []
 hostio = []
 mini-alloc = ["dep:mini-alloc"]
+stylus-test = ["dep:stylus-test", "dep:rclite", "stylus-proc/stylus-test"]
 reentrant = ["stylus-proc/reentrant", "stylus-core/reentrant", "stylus-test/reentrant"]
 hostio-caching = []

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -4,7 +4,7 @@
 //! Defines a struct that provides Stylus contracts access to a host VM
 //! environment via the HostAccessor trait defined in stylus_host. Makes contracts
 //! a lot more testable, as the VM can be mocked and injected upon initialization
-//! of a storage type. Defines two implementations, one when the stylus-test feature 
+//! of a storage type. Defines two implementations, one when the stylus-test feature
 //! is enabled and another that calls the actual HostIOs.
 
 use alloc::vec::Vec;

--- a/stylus-sdk/src/host/mod.rs
+++ b/stylus-sdk/src/host/mod.rs
@@ -4,8 +4,8 @@
 //! Defines a struct that provides Stylus contracts access to a host VM
 //! environment via the HostAccessor trait defined in stylus_host. Makes contracts
 //! a lot more testable, as the VM can be mocked and injected upon initialization
-//! of a storage type. Defines two implementations, one when the target arch is wasm32 and the
-//! other when the target is native.
+//! of a storage type. Defines two implementations, one when the stylus-test feature 
+//! is enabled and another that calls the actual HostIOs.
 
 use alloc::vec::Vec;
 use alloy_primitives::{Address, B256, U256};
@@ -28,7 +28,7 @@ pub mod calls;
 pub mod deploy;
 
 cfg_if::cfg_if! {
-    if #[cfg(target_arch = "wasm32")] {
+    if #[cfg(not(feature = "stylus-test"))] {
         use stylus_core::calls::*;
         use stylus_core::deploy::*;
 

--- a/stylus-sdk/src/lib.rs
+++ b/stylus-sdk/src/lib.rs
@@ -46,9 +46,9 @@ pub use stylus_proc;
 
 // If the target is a testing environment, we export the stylus test module as the `testing` crate
 // for Stylus SDK consumers, to be used as a test framework.
-#[cfg(all(not(target_arch = "wasm32"), test))]
+#[cfg(feature = "stylus-test")]
 pub use rclite as rc;
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 pub use stylus_test as testing;
 
 #[macro_use]

--- a/stylus-sdk/src/storage/array.rs
+++ b/stylus-sdk/src/storage/array.rs
@@ -50,7 +50,7 @@ impl<S: StorageType, const N: usize> StorageType for StorageArray<S, N> {
 impl<S: StorageType, const N: usize> HostAccess for StorageArray<S, N> {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -59,7 +59,7 @@ impl<S: StorageType, const N: usize> HostAccess for StorageArray<S, N> {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<const N: usize, S, T> From<&T> for StorageArray<S, N>
 where
     T: stylus_core::Host + Clone + 'static,

--- a/stylus-sdk/src/storage/bytes.rs
+++ b/stylus-sdk/src/storage/bytes.rs
@@ -51,7 +51,7 @@ impl StorageType for StorageBytes {
 impl HostAccess for StorageBytes {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -60,7 +60,7 @@ impl HostAccess for StorageBytes {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<T> From<&T> for StorageBytes
 where
     T: stylus_core::Host + Clone + 'static,
@@ -482,7 +482,7 @@ impl StorageType for StorageString {
 impl HostAccess for StorageString {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.0.__stylus_host
             } else {
                 self.0.__stylus_host.host.as_ref()
@@ -491,7 +491,7 @@ impl HostAccess for StorageString {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<T> From<&T> for StorageString
 where
     T: stylus_core::Host + Clone + 'static,

--- a/stylus-sdk/src/storage/map.rs
+++ b/stylus-sdk/src/storage/map.rs
@@ -57,7 +57,7 @@ where
 {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -66,7 +66,7 @@ where
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<K, V, T> From<&T> for StorageMap<K, V>
 where
     K: StorageKey,

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -54,7 +54,7 @@ impl GlobalStorage for StorageCache {
     /// Retrieves a 32-byte EVM word from persistent storage.
     fn get_word(vm: VM, key: U256) -> B256 {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 vm.storage_load_bytes32(key)
             } else {
                 vm.host.storage_load_bytes32(key)
@@ -69,7 +69,7 @@ impl GlobalStorage for StorageCache {
     /// May alias storage.
     unsafe fn set_word(vm: VM, key: U256, value: B256) {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 vm.storage_cache_bytes32(key, value)
             } else {
                 vm.host.storage_cache_bytes32(key, value)
@@ -176,7 +176,7 @@ where
 {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -185,7 +185,7 @@ where
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<const B: usize, const L: usize, T> From<&T> for StorageUint<B, L>
 where
     IntBitCount<B>: SupportedInt,
@@ -317,7 +317,7 @@ where
 {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -326,7 +326,7 @@ where
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<const B: usize, const L: usize, T> From<&T> for StorageSigned<B, L>
 where
     IntBitCount<B>: SupportedInt,
@@ -447,7 +447,7 @@ pub struct StorageFixedBytes<const N: usize> {
 impl<const N: usize> HostAccess for StorageFixedBytes<N> {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -503,7 +503,7 @@ where
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<const N: usize, T> From<&T> for StorageFixedBytes<N>
 where
     ByteCount<N>: SupportedFixedBytes,
@@ -568,7 +568,7 @@ pub struct StorageBool {
 impl HostAccess for StorageBool {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -577,7 +577,7 @@ impl HostAccess for StorageBool {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<T> From<&T> for StorageBool
 where
     T: stylus_core::Host + Clone + 'static,
@@ -680,7 +680,7 @@ pub struct StorageAddress {
 impl HostAccess for StorageAddress {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -689,7 +689,7 @@ impl HostAccess for StorageAddress {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<T> From<&T> for StorageAddress
 where
     T: stylus_core::Host + Clone + 'static,
@@ -794,7 +794,7 @@ pub struct StorageBlockNumber {
 impl HostAccess for StorageBlockNumber {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -803,7 +803,7 @@ impl HostAccess for StorageBlockNumber {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<T> From<&T> for StorageBlockNumber
 where
     T: stylus_core::Host + Clone + 'static,
@@ -909,7 +909,7 @@ pub struct StorageBlockHash {
 impl HostAccess for StorageBlockHash {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -918,7 +918,7 @@ impl HostAccess for StorageBlockHash {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<T> From<&T> for StorageBlockHash
 where
     T: stylus_core::Host + Clone + 'static,

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -50,7 +50,7 @@ impl<S: StorageType> StorageType for StorageVec<S> {
 impl<S: StorageType> HostAccess for StorageVec<S> {
     fn vm(&self) -> &dyn stylus_core::Host {
         cfg_if! {
-            if #[cfg(target_arch = "wasm32")] {
+            if #[cfg(not(feature = "stylus-test"))] {
                 &self.__stylus_host
             } else {
                 self.__stylus_host.host.as_ref()
@@ -59,7 +59,7 @@ impl<S: StorageType> HostAccess for StorageVec<S> {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "stylus-test")]
 impl<S, T> From<&T> for StorageVec<S>
 where
     S: StorageType,


### PR DESCRIPTION
This PR fixes cargo stylus replay after the release of 0.8.0. It adds a new feature flag to enable the TestVM mock instead of relying on the target architecture. It also removes an unnecessary call to `pay_for_memory_grow`, which caused a divergence between the trace and execution in previous versions of Nitro.

Close https://linear.app/offchain-labs/issue/STY-230