### PR TITLE
Add custom error when stylus-test is enabled for wasm32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 These crates follow [semver](https://semver.org).
 
-## [0.8.3](https://github.com/OffchainLabs/stylus-sdk-rs/releases/tag/v0.8.2) - 2025-03-13
+## [0.8.3](https://github.com/OffchainLabs/stylus-sdk-rs/releases/tag/v0.8.3) - TBD
 
 ### Fixed
 

--- a/stylus-sdk/src/lib.rs
+++ b/stylus-sdk/src/lib.rs
@@ -44,6 +44,9 @@ pub use keccak_const;
 pub use stylus_core;
 pub use stylus_proc;
 
+#[cfg(all(feature = "stylus-test", target_arch = "wasm32"))]
+compile_error!("The `stylus-test` feature should not be enabled for wasm32 targets");
+
 // If the target is a testing environment, we export the stylus test module as the `testing` crate
 // for Stylus SDK consumers, to be used as a test framework.
 #[cfg(feature = "stylus-test")]


### PR DESCRIPTION
And also fix the CHANGELOG. When we are ready to release, we should update it with the correct date.