### PR TITLE
add `StorageU96` int alias

### DIFF
--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -135,6 +135,7 @@ alias_ints! {
     StorageU16, StorageI16, 16, 1;
     StorageU32, StorageI32, 32, 1;
     StorageU64, StorageI64, 64, 1;
+    StorageU96, StorageI96, 96, 2;
     StorageU128, StorageI128, 128, 2;
     StorageU160, StorageI160, 160, 3;
     StorageU192, StorageI192, 192, 3;


### PR DESCRIPTION
## Description

We need this to implement [Erc721Consecutive](https://github.com/OpenZeppelin/rust-contracts-stylus/blob/9e840ca53c21a68e0878aaa4bbffac08234f853e/contracts/src/token/erc721/extensions/consecutive.rs#L50) and [Erc2981](https://github.com/OpenZeppelin/rust-contracts-stylus/blob/9e840ca53c21a68e0878aaa4bbffac08234f853e/contracts/src/token/common/erc2981.rs#L37)

## Checklist

- [ ] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
