### PR TITLE
Remove mark_used function to reduce binary size

### DIFF
--- a/stylus-proc/src/macros/entrypoint.rs
+++ b/stylus-proc/src/macros/entrypoint.rs
@@ -27,7 +27,6 @@ pub fn entrypoint(
 
 struct Entrypoint {
     kind: EntrypointKind,
-    mark_used_fn: syn::ItemFn,
     user_entrypoint_fn: syn::ItemFn,
 }
 impl Parse for Entrypoint {
@@ -48,7 +47,6 @@ impl Parse for Entrypoint {
 
         Ok(Self {
             user_entrypoint_fn: user_entrypoint_fn(kind.entrypoint_fn_name()),
-            mark_used_fn: mark_used_fn(),
             kind,
         })
     }
@@ -57,7 +55,6 @@ impl Parse for Entrypoint {
 impl ToTokens for Entrypoint {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.kind.to_tokens(tokens);
-        self.mark_used_fn.to_tokens(tokens);
         self.user_entrypoint_fn.to_tokens(tokens);
     }
 }
@@ -143,18 +140,6 @@ fn assert_overrides_const(name: &Ident) -> syn::ItemConst {
     }
 }
 
-fn mark_used_fn() -> syn::ItemFn {
-    parse_quote! {
-        #[cfg(not(feature = "stylus-test"))]
-        #[no_mangle]
-        pub unsafe fn mark_used() {
-            let host = stylus_sdk::host::VM(stylus_sdk::host::WasmVM{});
-            host.pay_for_memory_grow(0);
-            panic!();
-        }
-    }
-}
-
 fn user_entrypoint_fn(user_fn: Ident) -> syn::ItemFn {
     let deny_reentrant = deny_reentrant();
     parse_quote! {
@@ -163,6 +148,14 @@ fn user_entrypoint_fn(user_fn: Ident) -> syn::ItemFn {
         pub extern "C" fn user_entrypoint(len: usize) -> usize {
             let host = stylus_sdk::host::VM(stylus_sdk::host::WasmVM{});
             #deny_reentrant
+
+            // The following call is a noop to ensure that pay_for_memory_grow is
+            // referenced by the Stylus contract. Later, when the contract is activated,
+            // Nitro will automatically add the calls pay_for_memory_grow when memory is
+            // dynamically allocated. If we do not add this call here, the calls added by
+            // Nitro will not work and activation will fail. This call costs 8700 Ink,
+            // which is less than 1 Gas.
+            host.pay_for_memory_grow(0);
 
             let input = host.read_args(len);
             let (data, status) = match #user_fn(input, host.clone()) {


### PR DESCRIPTION
The mark_used function was never called, it existed so the contract could have a reference to the `pay_for_memory_grow` host-io. We moved this reference to the entrypoint, saving 360 bytes of the final compressed binary size. The reason why we need the call to `pay_for_memory_grow` is explained in the code.

Close https://linear.app/offchain-labs/issue/STY-234