### PR TITLE
Remove the HostIO-caching feature

### DIFF
--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -43,7 +43,7 @@ stylus-sdk = { workspace = true, features = ["stylus-test"] }
 features = ["default", "docs", "debug", "export-abi", "stylus-test"]
 
 [features]
-default = ["mini-alloc", "hostio-caching"]
+default = ["mini-alloc"]
 export-abi = ["debug", "regex", "stylus-proc/export-abi", "alloy-primitives/tiny-keccak"]
 debug = []
 docs = []
@@ -51,4 +51,3 @@ hostio = []
 mini-alloc = ["dep:mini-alloc"]
 stylus-test = ["dep:stylus-test", "dep:rclite", "stylus-proc/stylus-test"]
 reentrant = ["stylus-proc/reentrant", "stylus-core/reentrant", "stylus-test/reentrant"]
-hostio-caching = []

--- a/stylus-sdk/src/block.rs
+++ b/stylus-sdk/src/block.rs
@@ -17,23 +17,23 @@ use alloy_primitives::{Address, B256, U256};
 
 wrap_hostio!(
     /// Gets the basefee of the current block.
-    basefee BASEFEE block_basefee U256
+    basefee block_basefee U256
 );
 
 wrap_hostio!(
     /// Gets the unique chain identifier of the Arbitrum chain.
-    chainid CHAINID chainid u64
+    chainid chainid u64
 );
 
 wrap_hostio!(
     /// Gets the coinbase of the current block, which on Arbitrum chains is the L1 batch poster's
     /// address.
-    coinbase COINBASE block_coinbase Address
+    coinbase block_coinbase Address
 );
 
 wrap_hostio!(
     /// Gets the gas limit of the current block.
-    gas_limit GAS_LIMIT block_gas_limit u64
+    gas_limit block_gas_limit u64
 );
 
 wrap_hostio!(
@@ -42,7 +42,7 @@ wrap_hostio!(
     /// determined.
     ///
     /// [`Block Numbers and Time`]: https://developer.arbitrum.io/time
-    number NUMBER block_number u64
+    number block_number u64
 );
 
 wrap_hostio!(
@@ -51,5 +51,5 @@ wrap_hostio!(
     /// determined.
     ///
     /// [`Block Numbers and Time`]: https://developer.arbitrum.io/time
-    timestamp TIMESTAMP block_timestamp u64
+    timestamp block_timestamp u64
 );

--- a/stylus-sdk/src/call/raw.rs
+++ b/stylus-sdk/src/call/raw.rs
@@ -226,12 +226,6 @@ impl RawCall {
                 }
             };
 
-            cfg_if::cfg_if! {
-                if #[cfg(feature = "hostio-caching")] {
-                    crate::contract::RETURN_DATA_LEN.set(outs_len);
-                }
-            }
-
             let outs = crate::contract::read_return_data(self.offset, self.size);
             match status {
                 0 => Ok(outs),

--- a/stylus-sdk/src/contract.rs
+++ b/stylus-sdk/src/contract.rs
@@ -70,12 +70,12 @@ pub fn read_return_data(offset: usize, size: Option<usize>) -> Vec<u8> {
 wrap_hostio!(
     /// Returns the length of the last EVM call or deployment return result, or `0` if neither have
     /// happened during the program's execution.
-    return_data_len RETURN_DATA_LEN return_data_size usize
+    return_data_len return_data_size usize
 );
 
 wrap_hostio!(
     /// Gets the address of the current program.
-    address ADDRESS contract_address Address
+    address contract_address Address
 );
 
 /// Gets the balance of the current program.

--- a/stylus-sdk/src/deploy/raw.rs
+++ b/stylus-sdk/src/deploy/raw.rs
@@ -104,11 +104,6 @@ impl RawDeploy {
                 &mut revert_data_len as *mut _,
             );
         }
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "hostio-caching")] {
-                crate::contract::RETURN_DATA_LEN.set(revert_data_len);
-            }
-        }
 
         if contract.is_zero() {
             #[allow(deprecated)]

--- a/stylus-sdk/src/msg.rs
+++ b/stylus-sdk/src/msg.rs
@@ -17,7 +17,7 @@ use alloy_primitives::{Address, B256, U256};
 
 wrap_hostio!(
     /// Whether the current call is reentrant.
-    reentrant REENTRANT msg_reentrant bool
+    reentrant msg_reentrant bool
 );
 
 wrap_hostio!(
@@ -31,10 +31,10 @@ wrap_hostio!(
     /// [`CALLER`]: https://www.evm.codes/#33
     /// [`DELEGATE_CALL`]: https://www.evm.codes/#f4
     /// [`Retryable Ticket Address Aliasing`]: https://developer.arbitrum.io/arbos/l1-to-l2-messaging#address-aliasing
-    sender SENDER msg_sender Address
+    sender msg_sender Address
 );
 
 wrap_hostio!(
     /// Get the ETH value in wei sent to the program.
-    value VALUE msg_value U256
+    value msg_value U256
 );

--- a/stylus-sdk/src/tx.rs
+++ b/stylus-sdk/src/tx.rs
@@ -20,7 +20,7 @@ wrap_hostio! {
     /// Stylus's compute-pricing model.
     ///
     /// [`Ink and Gas`]: https://docs.arbitrum.io/stylus/concepts/gas-metering
-    ink_price INK_PRICE tx_ink_price u32
+    ink_price tx_ink_price u32
 }
 
 /// Converts evm gas to ink. See [`Ink and Gas`] for more information on
@@ -51,7 +51,7 @@ pub fn ink_to_gas(ink: u64) -> u64 {
 
 wrap_hostio!(
     /// Gets the gas price in wei per gas, which on Arbitrum chains equals the basefee.
-    gas_price GAS_PRICE tx_gas_price U256
+    gas_price tx_gas_price U256
 );
 
 wrap_hostio!(
@@ -59,5 +59,5 @@ wrap_hostio!(
     /// EVM's [`ORIGIN`] opcode.
     ///
     /// [`ORIGIN`]: https://www.evm.codes/#32
-    origin ORIGIN tx_origin Address
+    origin tx_origin Address
 );


### PR DESCRIPTION
Removing this feature reduces the contract binary size and the gas usage when the cache is not hit. The caching added an overhead that required it to hit dozens of times to be worth it.

Users are advised to add caching in the form of local variables if the contract calls the same HostIO multiple times.

Close [STY-235](https://linear.app/offchain-labs/issue/STY-235)