### PR TITLE
Add barebones stylus-tools crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2916,6 +2916,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "stylus-tools"
+version = "0.8.3"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["stylus-sdk", "stylus-proc", "stylus-test", "mini-alloc", "stylus-core"]
+members = ["stylus-sdk", "stylus-proc", "stylus-test", "mini-alloc", "stylus-core", "stylus-tools"]
 resolver = "2"
 
 [workspace.package]

--- a/stylus-tools/Cargo.toml
+++ b/stylus-tools/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "stylus-tools"
+keywords = ["arbitrum", "ethereum", "stylus", "alloy"]
+description = "Tools to compile, deploy and verify Arbitrum Stylus contracts"
+readme = "../README.md"
+
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]

--- a/stylus-tools/src/lib.rs
+++ b/stylus-tools/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
This new crate will provide the core functionality to compile, deploy, and verify Stylus contracts. We will migrate most of cargo-stylus code to stylus-tools so that it can be used as a library by other projects and cargo-stylus will be just a thin wrapper on top of it.
