### PR TITLE
Be more strict with special function names

### DIFF
--- a/stylus-proc/src/macros/public/mod.rs
+++ b/stylus-proc/src/macros/public/mod.rs
@@ -32,6 +32,20 @@ cfg_if! {
     }
 }
 
+/// Check whether the function has a special name that matches its kind.
+macro_rules! check_special_name {
+    ($node:expr, $name:expr, $kind:expr, $( ($special_name:literal, $expected_kind:pat) ),* $(,)? ) => {
+        $(
+            if $name == $special_name && !matches!($kind, $expected_kind) {
+                emit_error!(
+                    $node.span(),
+                    concat!($special_name, " function can only be defined using the corresponding attribute")
+                );
+            }
+        )*
+    };
+}
+
 /// Implementation of the [`#[public]`][crate::public] macro.
 ///
 /// This implementation performs the following steps:
@@ -150,18 +164,20 @@ impl<E: FnExtension> From<&mut syn::ImplItemFn> for PublicFn<E> {
 
         // name for generated rust, and solidity abi
         let name = node.sig.ident.clone();
-        for special_name in ["receive", "fallback", "constructor"] {
-            if matches!(kind, FnKind::Function) && name == special_name {
-                emit_error!(
-                    node.span(),
-                    format!("{special_name} function can only be defined using the #[{special_name}] attribute")
-                );
-            }
-        }
-
-        let sol_name = syn_solidity::SolIdent::new(
-            &selector_override.unwrap_or(name.to_string().to_case(Case::Camel)),
+        let sol_name = selector_override
+            .unwrap_or(name.to_string())
+            .to_case(Case::Camel);
+        check_special_name!(
+            node,
+            sol_name,
+            kind,
+            ("receive", FnKind::Receive),
+            ("fallback", FnKind::Fallback { .. }),
+            ("constructor", FnKind::Constructor),
+            ("stylusConstructor", FnKind::Constructor),
         );
+
+        let sol_name = syn_solidity::SolIdent::new(&sol_name);
 
         // determine state mutability
         let (inferred_purity, has_self) = Purity::infer(node);

--- a/stylus-proc/tests/fail/public/constructor.rs
+++ b/stylus-proc/tests/fail/public/constructor.rs
@@ -9,13 +9,34 @@ struct Contract {}
 
 #[public]
 impl Contract {
+    // error: function can be only one of fallback, receive or constructor
+    #[fallback]
+    #[receive]
+    #[constructor]
+    fn init() {}
+    
+    // error: fallback, receive, and constructor can't have custom selector
     #[constructor]
     #[selector(name = "foo")]
-    #[fallback]
-    fn init() {}
+    fn constr() {}
 
-    // constructor without annotation
+    // error: constructor function can only be defined using the corresponding attribute
     fn constructor() {}
+
+    // error: constructor function can only be defined using the corresponding attribute
+    #[receive]
+    fn constructor() {}
+
+    // error: stylusConstructor function can only be defined using the corresponding attribute
+    fn stylus_constructor() {}
+
+    // error: stylusConstructor function can only be defined using the corresponding attribute
+    #[selector(name = "stylus_constructor")]
+    fn foo() {}
+
+    // error: stylusConstructor function can only be defined using the corresponding attribute
+    #[selector(name = "stylusConstructor")]
+    fn foo() {}
 }
 
 fn main() {}

--- a/stylus-proc/tests/fail/public/constructor.stderr
+++ b/stylus-proc/tests/fail/public/constructor.stderr
@@ -1,17 +1,41 @@
 error: function can be only one of fallback, receive or constructor
-  --> tests/fail/public/constructor.rs:15:5
+  --> tests/fail/public/constructor.rs:16:5
    |
-15 |     fn init() {}
+16 |     fn init() {}
    |     ^^
 
 error: fallback, receive, and constructor can't have custom selector
-  --> tests/fail/public/constructor.rs:15:5
+  --> tests/fail/public/constructor.rs:21:5
    |
-15 |     fn init() {}
+21 |     fn constr() {}
    |     ^^
 
-error: constructor function can only be defined using the #[constructor] attribute
-  --> tests/fail/public/constructor.rs:18:5
+error: constructor function can only be defined using the corresponding attribute
+  --> tests/fail/public/constructor.rs:24:5
    |
-18 |     fn constructor() {}
+24 |     fn constructor() {}
+   |     ^^
+
+error: constructor function can only be defined using the corresponding attribute
+  --> tests/fail/public/constructor.rs:28:5
+   |
+28 |     fn constructor() {}
+   |     ^^
+
+error: stylusConstructor function can only be defined using the corresponding attribute
+  --> tests/fail/public/constructor.rs:31:5
+   |
+31 |     fn stylus_constructor() {}
+   |     ^^
+
+error: stylusConstructor function can only be defined using the corresponding attribute
+  --> tests/fail/public/constructor.rs:35:5
+   |
+35 |     fn foo() {}
+   |     ^^
+
+error: stylusConstructor function can only be defined using the corresponding attribute
+  --> tests/fail/public/constructor.rs:39:5
+   |
+39 |     fn foo() {}
    |     ^^


### PR DESCRIPTION
Check whether the function with a special name has a matching attribute. This ensures there isn't a routing conflict that could be exploited.

Close STY-254
Close M-03
