### PR TITLE
Don't use std for stylus-core, lint to ignore alloc_impl unsafe

### DIFF
--- a/mini-alloc/src/imp.rs
+++ b/mini-alloc/src/imp.rs
@@ -45,6 +45,7 @@ extern "C" {
 static mut STATE: Option<(NonZero, usize)> = None;
 
 unsafe fn alloc_impl(layout: Layout) -> Option<*mut u8> {
+    #[allow(mutable_borrow_reservation_conflict)]
     let (neg_offset, neg_bound) = STATE.get_or_insert_with(|| {
         let heap_base = &__heap_base as *const u8 as usize;
         let bound = MiniAlloc::PAGE_SIZE * wasm32::memory_size(0) - 1;

--- a/stylus-core/src/calls/mod.rs
+++ b/stylus-core/src/calls/mod.rs
@@ -3,6 +3,8 @@
 
 use alloy_primitives::{Address, U256};
 
+use alloc::vec::Vec;
+
 pub mod context;
 pub mod errors;
 

--- a/stylus-core/src/deploy.rs
+++ b/stylus-core/src/deploy.rs
@@ -3,6 +3,8 @@
 
 extern crate alloc;
 
+use alloc::vec::Vec;
+
 use alloy_primitives::{Address, B256, U256};
 
 /// How to manage the storage cache, if enabled.

--- a/stylus-core/src/lib.rs
+++ b/stylus-core/src/lib.rs
@@ -1,13 +1,20 @@
 // Copyright 2024-2025, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
+#![no_std]
 
 //! Defines host environment methods Stylus SDK contracts have access to.
+
+extern crate alloc;
+
 pub mod calls;
 pub mod deploy;
 pub mod host;
 pub mod storage;
 
 use alloy_sol_types::{abi::token::WordToken, SolEvent, TopicList};
+
+use alloc::vec::Vec;
+
 pub use host::*;
 pub use storage::TopLevelStorage;
 


### PR DESCRIPTION
## Description

These changes ensure that `stylus_core` no longer uses std, though without a check for `export-abi`, which I assume is not needed in this code. It also enables a lint for `mini-alloc` that prevents a message about discouraged use of mutable statics.

## Checklist

- [X] I have documented these changes where necessary.
- [X] I have read the [DCO][DCO] and ensured that these changes comply.
- [X] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
