### PR TITLE
Panic when using HostIOs with stylus test

### DIFF
--- a/stylus-sdk/src/hostio.rs
+++ b/stylus-sdk/src/hostio.rs
@@ -50,6 +50,15 @@ macro_rules! vm_hooks {
                     )*
                 }
                 pub use $stub::*;
+            } else if #[cfg(feature = "stylus-test")] {
+                $(#[$block_meta])*
+                $(
+                    $(#[$meta])*
+                    #[allow(unused, unused_variables, clippy::missing_safety_doc)]
+                    $vis unsafe fn $func($($arg : $arg_type),*) $(-> $return_type)? {
+                        panic!("HostIO functions are not available in stylus-test. Use TestVM functions instead.");
+                    }
+                )*
             } else {
                 // Generate a wasm import for each function.
                 $(#[$block_meta])*
@@ -460,3 +469,17 @@ macro_rules! wrap_hostio {
 }
 
 pub(crate) use wrap_hostio;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_hostio_panics_in_test() {
+        // The test environment does not support mocking HostIO functions
+        unsafe {
+            _ = chainid();
+        }
+    }
+}


### PR DESCRIPTION
The stylus-test feature does not support mocking the HostIO functions directly. Instead, the developer should use the TestVM infrastructure. The panic will clarify why the tests are not working as expected.

Close STY-258
