### PR TITLE
feat: Add Support for Associated Types in Contracts

### DIFF
--- a/stylus-proc/src/macros/public/mod.rs
+++ b/stylus-proc/src/macros/public/mod.rs
@@ -109,6 +109,14 @@ impl From<&mut syn::ItemImpl> for PublicImpl {
             _ => None,
         };
 
+        // Extract associated types from the impl items
+        let mut associated_types = Vec::new();
+        for item in &node.items {
+            if let syn::ImplItem::Type(type_item) = item {
+                associated_types.push((type_item.ident.clone(), type_item.ty.clone()));
+            }
+        }
+
         #[allow(clippy::let_unit_value)]
         let extension = <Extension as InterfaceExtension>::build(node);
         Self {
@@ -119,6 +127,7 @@ impl From<&mut syn::ItemImpl> for PublicImpl {
             inheritance,
             implements,
             funcs,
+            associated_types,
             extension,
         }
     }

--- a/stylus-proc/src/macros/public/types.rs
+++ b/stylus-proc/src/macros/public/types.rs
@@ -54,6 +54,7 @@ pub struct PublicImpl<E: InterfaceExtension = Extension> {
     pub inheritance: Vec<syn::Type>,
     pub implements: Vec<syn::Type>,
     pub funcs: Vec<PublicFn<E::FnExt>>,
+    pub associated_types: Vec<(syn::Ident, syn::Type)>, // New field to store associated types
     #[allow(dead_code)]
     pub extension: E,
 }
@@ -121,8 +122,24 @@ impl PublicImpl {
 
         let implements_routes = self.implements_routes();
 
+        // Determine trait dynamic interface with associated types
         let iface = match &self.trait_ {
-            Some(trait_) => &parse_quote! { dyn #trait_ },
+            Some(trait_) => {
+                // Use the stored associated types
+                if !self.associated_types.is_empty() {
+                    let assoc_types_formatted = self
+                        .associated_types
+                        .iter()
+                        .map(|(name, value)| {
+                            quote! { #name = #value }
+                        })
+                        .collect::<Vec<_>>();
+
+                    &parse_quote! { dyn #trait_ < #(#assoc_types_formatted),* > }
+                } else {
+                    &parse_quote! { dyn #trait_ }
+                }
+            }
             None => self_ty,
         };
 

--- a/stylus-proc/src/macros/public/types.rs
+++ b/stylus-proc/src/macros/public/types.rs
@@ -54,7 +54,7 @@ pub struct PublicImpl<E: InterfaceExtension = Extension> {
     pub inheritance: Vec<syn::Type>,
     pub implements: Vec<syn::Type>,
     pub funcs: Vec<PublicFn<E::FnExt>>,
-    pub associated_types: Vec<(syn::Ident, syn::Type)>, // New field to store associated types
+    pub associated_types: Vec<(syn::Ident, syn::Type)>,
     #[allow(dead_code)]
     pub extension: E,
 }
@@ -125,7 +125,6 @@ impl PublicImpl {
         // Determine trait dynamic interface with associated types
         let iface = match &self.trait_ {
             Some(trait_) => {
-                // Use the stored associated types
                 if !self.associated_types.is_empty() {
                     let assoc_types_formatted = self
                         .associated_types


### PR DESCRIPTION
It works great with the new inheritance model and is necessary for good developer experience.

Without this support, it would be impossible to inherit contracts that return specific error enums, so devs (our OZ library included) would have to rely on plain `Vec<u8>` for errors.