### PR TITLE
Fix selector override in public proc macro

### DIFF
--- a/stylus-proc/tests/fail/public/constructor.rs
+++ b/stylus-proc/tests/fail/public/constructor.rs
@@ -27,14 +27,10 @@ impl Contract {
     #[receive]
     fn constructor() {}
 
-    // error: stylusConstructor function can only be defined using the corresponding attribute
+    // error: constructor function can only be defined using the corresponding attribute
     fn stylus_constructor() {}
 
-    // error: stylusConstructor function can only be defined using the corresponding attribute
-    #[selector(name = "stylus_constructor")]
-    fn foo() {}
-
-    // error: stylusConstructor function can only be defined using the corresponding attribute
+    // error: constructor function can only be defined using the corresponding attribute
     #[selector(name = "stylusConstructor")]
     fn foo() {}
 }

--- a/stylus-proc/tests/fail/public/constructor.stderr
+++ b/stylus-proc/tests/fail/public/constructor.stderr
@@ -22,20 +22,14 @@ error: constructor function can only be defined using the corresponding attribut
 28 |     fn constructor() {}
    |     ^^
 
-error: stylusConstructor function can only be defined using the corresponding attribute
+error: constructor function can only be defined using the corresponding attribute
   --> tests/fail/public/constructor.rs:31:5
    |
 31 |     fn stylus_constructor() {}
    |     ^^
 
-error: stylusConstructor function can only be defined using the corresponding attribute
+error: constructor function can only be defined using the corresponding attribute
   --> tests/fail/public/constructor.rs:35:5
    |
 35 |     fn foo() {}
-   |     ^^
-
-error: stylusConstructor function can only be defined using the corresponding attribute
-  --> tests/fail/public/constructor.rs:39:5
-   |
-39 |     fn foo() {}
    |     ^^


### PR DESCRIPTION
Ensure the override is not converted into camelCase. Previously, the override set to tokenURI became tokenUri. Also, add some unit tests to ensure this doesn't happen again.

Close STY-266
