### PR TITLE
Don't depend on the crate alloy_primitives being available separately

### DIFF
--- a/stylus-proc/src/macros/storage.rs
+++ b/stylus-proc/src/macros/storage.rs
@@ -167,7 +167,7 @@ impl Storage {
         parse_quote! {
             impl #impl_generics stylus_sdk::stylus_core::host::ValueDenier for #name #ty_generics #where_clause {
                 fn deny_value(&self, method_name: &str) -> Result<(), Vec<u8>> {
-                    if self.vm().msg_value() == alloy_primitives::U256::ZERO {
+                    if self.vm().msg_value() == stylus_sdk::alloy_primitives::U256::ZERO {
                         return Ok(());
                     }
                     stylus_sdk::console!("method {method_name} not payable");


### PR DESCRIPTION
## Description

Make it possible for the macro to generate the entrypoint without needing `alloy_primitives` to be available as a separate crate.

## Checklist

- [X] I have documented these changes where necessary.
- [X] I have read the [DCO][DCO] and ensured that these changes comply.
- [X] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
