### PR TITLE
Add some helper functions to make integer setting easier

### DIFF
--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -233,6 +233,7 @@ where
         wrapping_mul,
 
         /// Set the modulo of the value, panicking if rhs is 0.
+        /// Returns the new value.
         wrapping_rem
     }
 

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -230,7 +230,10 @@ where
 
         /// Multiply the underlying value, wrapping around if overflow.
         /// Returns the new value.
-        wrapping_mul
+        wrapping_mul,
+
+        /// Set the modulo of the value, panicking if rhs is 0.
+        wrapping_rem
     }
 
     gen_int_checked_ops! {
@@ -244,7 +247,11 @@ where
         checked_div,
 
         /// Multiply the underlying value, returning None if overflow.
-        checked_mul
+        checked_mul,
+
+        /// Set the modulo of the value, returning None if overflow or rhs
+        /// is 0.
+        checked_rem,
     }
 }
 

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -238,20 +238,24 @@ where
     }
 
     gen_int_checked_ops! {
-        /// Add to the underlying value, returning None if overflow.
+        /// Add to the underlying value, only setting if the value does not
+        /// overflow. Returns the value if set.
         update_check_add,
 
-        /// Subtract from the underlying value, returning None if overflow.
+        /// Subtract from the underlying value, only setting if the value does not
+        /// overflow. Returns the value if set.
         update_check_sub,
 
-        /// Divide the underlying value, returning None if overflow.
+        /// Divide the underlying value, only setting if the value does not
+        /// overflow. Returns the value if set.
         update_check_div,
 
-        /// Multiply the underlying value, returning None if overflow.
+        /// Divide the underlying value, only setting if the value does not
+        /// overflow. Returns the value if set.
         update_check_mul,
 
         /// Set the modulo of the value, returning None if overflow or rhs
-        /// is 0.
+        /// is 0, only setting if the value would be Some. Returns the result.
         update_check_rem,
     }
 }

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -172,21 +172,26 @@ where
 }
 
 macro_rules! gen_int_wrap_ops {
-    ($( $(#[$docs:meta])* $name:ident ),* $(,)?) => {
-        $( $(#[$docs])*
-           pub fn $name(&mut self, v: Uint<B,L>) -> Uint<B,L> {
-               let x = self.get().$name(v); self.set(x); x
-           }
+    ($( $(#[$docs:meta])* $fn:ident => $op:ident ),* $(,)?) => {
+        $(
+            $(#[$docs])*
+            #[inline]
+            pub fn $fn(&mut self, v: Uint<B, L>) -> Uint<B, L> {
+                let x = self.get().$op(v);
+                self.set(x);
+                x
+            }
         )*
     };
 }
 
 macro_rules! gen_int_checked_ops {
-    ($( $(#[$doc:meta])* $name:ident ),* $(,)?) => {
+    ($( $(#[$docs:meta])* $fn:ident => $op:ident ),* $(,)?) => {
         $(
-            $(#[$doc])*
-            pub fn $name(&mut self, v: Uint<B, L>) -> Option<Uint<B, L>> {
-                let r = self.get().$name(v);
+            $(#[$docs])*
+            #[inline]
+            pub fn $fn(&mut self, v: Uint<B, L>) -> Option<Uint<B, L>> {
+                let r = self.get().$op(v);
                 if let Some(x) = r { self.set(x); }
                 r
             }
@@ -218,45 +223,45 @@ where
     gen_int_wrap_ops! {
         /// Add to the underlying value, wrapping around if overflow.
         /// Returns the new value.
-        update_wrap_sub,
+        update_wrap_add => wrapping_add,
 
         /// Subtract the underlying value, wrapping around if overflow.
         /// Returns the new value.
-        update_wrap_sub,
+        update_wrap_sub => wrapping_sub,
 
         /// Divide the underlying value, wrapping around if overflow.
         /// Returns the new value.
-        update_wrap_div,
+        update_wrap_div => wrapping_div,
 
         /// Multiply the underlying value, wrapping around if overflow.
         /// Returns the new value.
-        update_wrap_mul,
+        update_wrap_mul => wrapping_mul,
 
         /// Set the modulo of the value, panicking if rhs is 0.
         /// Returns the new value.
-        update_wrap_rem
+        update_wrap_rem => wrapping_rem
     }
 
     gen_int_checked_ops! {
         /// Add to the underlying value, only setting if the value does not
         /// overflow. Returns the value if set.
-        update_check_add,
+        update_check_add => checked_add,
 
         /// Subtract from the underlying value, only setting if the value does not
         /// overflow. Returns the value if set.
-        update_check_sub,
+        update_check_sub => checked_sub,
 
         /// Divide the underlying value, only setting if the value does not
         /// overflow. Returns the value if set.
-        update_check_div,
+        update_check_div => checked_div,
 
         /// Divide the underlying value, only setting if the value does not
         /// overflow. Returns the value if set.
-        update_check_mul,
+        update_check_mul => checked_mul,
 
         /// Set the modulo of the value, returning None if overflow or rhs
         /// is 0, only setting if the value would be Some. Returns the result.
-        update_check_rem
+        update_check_rem => checked_rem
     }
 }
 

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -171,6 +171,29 @@ where
     }
 }
 
+macro_rules! gen_int_wrap_ops {
+    ($( $(#[$docs:meta])* $name:ident ),* $(,)?) => {
+        $( $(#[$docs])*
+           pub fn $name(&mut self, v: Uint<B,L>) -> Uint<B,L> {
+               let x = self.get().$name(v); self.set(x); x
+           }
+        )*
+    };
+}
+
+macro_rules! gen_int_checked_ops {
+    ($( $(#[$doc:meta])* $name:ident ),* $(,)?) => {
+        $(
+            $(#[$doc])*
+            pub fn $name(&mut self, v: Uint<B, L>) -> Option<Uint<B, L>> {
+                let r = self.get().$name(v);
+                if let Some(x) = r { self.set(x); }
+                r
+            }
+        )*
+    };
+}
+
 impl<const B: usize, const L: usize> StorageUint<B, L>
 where
     IntBitCount<B>: SupportedInt,
@@ -190,6 +213,38 @@ where
                 value,
             )
         };
+    }
+
+    gen_int_wrap_ops! {
+        /// Add to the underlying value, wrapping around if overflow.
+        /// Returns the new value.
+        wrapping_add,
+
+        /// Subtract the underlying value, wrapping around if overflow.
+        /// Returns the new value.
+        wrapping_sub,
+
+        /// Divide the underlying value, wrapping around if overflow.
+        /// Returns the new value.
+        wrapping_div,
+
+        /// Multiply the underlying value, wrapping around if overflow.
+        /// Returns the new value.
+        wrapping_mul
+    }
+
+    gen_int_checked_ops! {
+        /// Add to the underlying value, returning None if overflow.
+        checked_add,
+
+        /// Subtract from the underlying value, returning None if overflow.
+        checked_sub,
+
+        /// Divide the underlying value, returning None if overflow.
+        checked_div,
+
+        /// Multiply the underlying value, returning None if overflow.
+        checked_mul
     }
 }
 

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -256,7 +256,7 @@ where
 
         /// Set the modulo of the value, returning None if overflow or rhs
         /// is 0, only setting if the value would be Some. Returns the result.
-        update_check_rem,
+        update_check_rem
     }
 }
 

--- a/stylus-sdk/src/storage/mod.rs
+++ b/stylus-sdk/src/storage/mod.rs
@@ -218,41 +218,41 @@ where
     gen_int_wrap_ops! {
         /// Add to the underlying value, wrapping around if overflow.
         /// Returns the new value.
-        wrapping_add,
+        update_wrap_sub,
 
         /// Subtract the underlying value, wrapping around if overflow.
         /// Returns the new value.
-        wrapping_sub,
+        update_wrap_sub,
 
         /// Divide the underlying value, wrapping around if overflow.
         /// Returns the new value.
-        wrapping_div,
+        update_wrap_div,
 
         /// Multiply the underlying value, wrapping around if overflow.
         /// Returns the new value.
-        wrapping_mul,
+        update_wrap_mul,
 
         /// Set the modulo of the value, panicking if rhs is 0.
         /// Returns the new value.
-        wrapping_rem
+        update_wrap_rem
     }
 
     gen_int_checked_ops! {
         /// Add to the underlying value, returning None if overflow.
-        checked_add,
+        update_check_add,
 
         /// Subtract from the underlying value, returning None if overflow.
-        checked_sub,
+        update_check_sub,
 
         /// Divide the underlying value, returning None if overflow.
-        checked_div,
+        update_check_div,
 
         /// Multiply the underlying value, returning None if overflow.
-        checked_mul,
+        update_check_mul,
 
         /// Set the modulo of the value, returning None if overflow or rhs
         /// is 0.
-        checked_rem,
+        update_check_rem,
     }
 }
 


### PR DESCRIPTION
## Description

Add some integer functions to add to, subtract, or divide from the underlying storage units.

In my opinion, it's better to add some extra functions to do this, even if the team has made a conscious decision to require the end user to make any modifications to storage values before doing the setting. This is just too common of a pattern, and using nested storage values is a huge pain with a get, add, then set, due to Rust making sure the value isn't dropped midway. Having a simple setter that adds, multiplies, divides, etc, will improve this experience.

## Checklist

- [X] I have documented these changes where necessary.
- [X] I have read the [DCO][DCO] and ensured that these changes comply.
- [X] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
