### PR TITLE
Add explanation of why our brotli2 usage is safe.

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,10 @@
+[advisories]
+ignore = [
+    # The vulnerability in brotli-sys cannot be exploited in the Stylus SDK. We
+    # are only using the `brotli2::read::BrotliEncoder`, which wraps the reader
+    # in a `std::io::BufReader`, using the default buffer size of 8KiB. This
+    # ensures that no payload of >2GiB is sent to the C API. Additionally, we
+    # only use this library as part of the build-time tooling, so there is never
+    # any risk to the node itself.
+    "RUSTSEC-2021-0131",
+]


### PR DESCRIPTION
## Description

This fixes the reporting of RUSTSEC-2021-0131 by cargo audit.


## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
