### PR TITLE
Add a test of pure method in a routable trait

### DIFF
--- a/stylus-proc/tests/public_composition.rs
+++ b/stylus-proc/tests/public_composition.rs
@@ -24,7 +24,7 @@ struct Contract {
 }
 
 #[public]
-#[implements(IErc20, IOwnable)]
+#[implements(IErc20, IOwnable, PureTrait)]
 impl Contract {}
 
 #[storage]
@@ -89,4 +89,15 @@ impl IOwnable for Contract {
     fn renounce_ownership(&mut self) -> bool {
         todo!()
     }
+}
+
+trait PureTrait {
+    fn pure_method()
+    where
+        Self: Sized;
+}
+
+#[public]
+impl PureTrait for Contract {
+    fn pure_method() {}
 }


### PR DESCRIPTION
## Description

This test shows an example of how one might use a pure method in a routable trait. We could potentially make a proc macro for routable traits that removes this boilerplate, but it is not too terrible IMO.

```
trait MyTrait {
    fn pure_method() where Self: Sized;
}
```

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
