### PR TITLE
Fix trybuild tests

### DIFF
--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -26,4 +26,6 @@ cargo check --locked -F $FEATURES
 cargo test --no-default-features -F $FEATURES
 
 # Run trybuild tests separately without other features
-cargo test -p stylus-proc -F trybuild-tests
+if [[ "${CFG_RELEASE_CHANNEL-}" != "nightly"* ]]; then
+    cargo test -p stylus-proc -F trybuild-tests
+fi

--- a/ci/build_and_test.sh
+++ b/ci/build_and_test.sh
@@ -17,12 +17,13 @@ FEATURES=$(echo "$FEATURES" | grep . | sort | uniq | grep -v default) # cleanup
 FEATURES=$(echo "$FEATURES" | grep -v integration-tests)
 
 # Remove trybuild tests on nightly because they depend on the compiler output.
-if [[ "${CFG_RELEASE_CHANNEL-}" == "nightly"* ]]; then
-    FEATURES=$(echo "$FEATURES" | grep -v trybuild)
-fi
+FEATURES=$(echo "$FEATURES" | grep -v trybuild)
 
 FEATURES=$(echo $FEATURES | tr ' ' ',')
 echo "testing features: $FEATURES"
 
 cargo check --locked -F $FEATURES
 cargo test --no-default-features -F $FEATURES
+
+# Run trybuild tests separately without other features
+cargo test -p stylus-proc -F trybuild-tests


### PR DESCRIPTION
Run trybuild tests without other features enabled to get standardized error messages.