### PR TITLE
Don't allow selector override to use stylus_constructor

### DIFF
--- a/stylus-proc/src/macros/public/mod.rs
+++ b/stylus-proc/src/macros/public/mod.rs
@@ -237,7 +237,7 @@ fn verify_sol_name(
         Some("receive")
     } else if name_low == "fallback" && !matches!(kind, FnKind::Fallback { .. }) {
         Some("fallback")
-    } else if (name_low == "constructor" || name_low == "stylusconstructor")
+    } else if (name_low == "constructor" || name_low == "stylus_constructor")
         && !matches!(kind, FnKind::Constructor)
     {
         Some("constructor")

--- a/stylus-proc/tests/fail/public/constructor.rs
+++ b/stylus-proc/tests/fail/public/constructor.rs
@@ -14,7 +14,7 @@ impl Contract {
     #[receive]
     #[constructor]
     fn init() {}
-    
+
     // error: fallback, receive, and constructor can't have custom selector
     #[constructor]
     #[selector(name = "foo")]
@@ -28,12 +28,8 @@ impl Contract {
     fn constructor() {}
 
     // error: constructor function can only be defined using the corresponding attribute
-    fn stylus_constructor() {}
-
-    // error: constructor function can only be defined using the corresponding attribute
-    #[selector(name = "stylusConstructor")]
+    #[selector(name = "stylus_constructor")]
     fn foo() {}
 }
 
 fn main() {}
-

--- a/stylus-proc/tests/fail/public/constructor.stderr
+++ b/stylus-proc/tests/fail/public/constructor.stderr
@@ -23,13 +23,7 @@ error: constructor function can only be defined using the corresponding attribut
    |     ^^
 
 error: constructor function can only be defined using the corresponding attribute
-  --> tests/fail/public/constructor.rs:31:5
+  --> tests/fail/public/constructor.rs:32:5
    |
-31 |     fn stylus_constructor() {}
-   |     ^^
-
-error: constructor function can only be defined using the corresponding attribute
-  --> tests/fail/public/constructor.rs:35:5
-   |
-35 |     fn foo() {}
+32 |     fn foo() {}
    |     ^^


### PR DESCRIPTION
## Description

Resolves NIT-3745

Don't allow selector override to use stylus_constructor.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
