### PR TITLE
Underscore bytes in export-abi generation

### DIFF
--- a/stylus-sdk/src/abi/export/mod.rs
+++ b/stylus-sdk/src/abi/export/mod.rs
@@ -135,7 +135,7 @@ pub fn underscore_if_sol(name: &str) -> String {
         "" => "".to_string(),
 
         // other types
-        "address" | "bool" | "int" | "uint" => underscore(),
+        "address" | "bytes" | "bool" | "int" | "uint" => underscore(),
 
         // other words
         "is" | "contract" | "interface" => underscore(),


### PR DESCRIPTION
## Description

Resolves NIT-3744

Underscore bytes in export-abi generation

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
