### PR TITLE
Fixes toolchain related to installing setup-cargo-stylus to 1.88.0

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
       - name: Get latest cargo-stylus version
         id: get-version
         shell: bash

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.88.0
       - name: Get latest cargo-stylus version
         id: get-version
         shell: bash


### PR DESCRIPTION
## Description

Fixes toolchain related to installing setup-cargo-stylus to 1.88.0

This fixes the following [error](https://github.com/OffchainLabs/stylus-sdk-rs/actions/runs/17239860417/job/48913781561?pr=310):

```
  = note: /usr/bin/ld: /tmp/cargo-installYJQuAX/release/deps/libwasmer_vm-f4818818a1a5f0e6.rlib(wasmer_vm-f4818818a1a5f0e6.wasmer_vm.59152bd8713e9856-cgu.03.rcgu.o): in function `wasmer_vm::libcalls::function_pointer':
          wasmer_vm.59152bd8713e9856-cgu.03:(.text._ZN9wasmer_vm8libcalls16function_pointer17hdb9f81ce0aa62a37E+0x126): undefined reference to `__rust_probestack'
          /usr/bin/ld: /tmp/cargo-installYJQuAX/release/deps/libwasmer_vm-f4818818a1a5f0e6.rlib(wasmer_vm-f4818818a1a5f0e6.wasmer_vm.59152bd8713e9856-cgu.03.rcgu.o):(.data.rel.ro.wasmer_vm_probestack+0x0): undefined reference to `__rust_probestack'
          /usr/bin/ld: /tmp/cargo-installYJQuAX/release/deps/libwasmer_vm-f4818818a1a5f0e6.rlib(wasmer_vm-f4818818a1a5f0e6.wasmer_vm.59152bd8713e9856-cgu.15.rcgu.o):(.data.rel.ro._ZN9wasmer_vm10probestack10PROBESTACK17hfecd7908641fc503E+0x0): undefined reference to `__rust_probestack'
          collect2: error: ld returned 1 exit status
```

## Checklist
- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
