### PR TITLE
Mark StorageVec's truncate and shrink as unsafe

### DIFF
--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -191,7 +191,10 @@ impl<S: StorageType> StorageVec<S> {
     }
 
     /// Removes and returns an accessor to the last element of the vector, if any.
-    /// Note: this method does not erase any underlying storage, so it is unsafe.
+    ///
+    /// # Safety
+    ///
+    /// This fn does not erase any underlying storage.
     pub unsafe fn shrink(&mut self) -> Option<StorageGuardMut<'_, S>> {
         let index = match self.len() {
             0 => return None,
@@ -205,7 +208,9 @@ impl<S: StorageType> StorageVec<S> {
 
     /// Shortens the vector, keeping the first `len` elements.
     ///
-    /// Note: this method does not erase any underlying storage, so it is unsafe
+    /// # Safety
+    ///
+    /// This fn does not erase any underlying storage.
     pub unsafe fn truncate(&mut self, len: usize) {
         if len < self.len() {
             unsafe { self.set_len(len) }

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -282,7 +282,9 @@ impl<S: Erase> Erase for StorageVec<S> {
             let mut store = unsafe { self.accessor_unchecked(i) };
             store.erase()
         }
-        self.truncate(0);
+        unsafe {
+            self.truncate(0);
+        }
     }
 }
 

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -204,10 +204,9 @@ impl<S: StorageType> StorageVec<S> {
 
     /// Shortens the vector, keeping the first `len` elements.
     ///
-    /// Note: this method does not erase any underlying storage.
-    pub fn truncate(&mut self, len: usize) {
+    /// Note: this method does not erase any underlying storage, so it is unsafe
+    pub unsafe fn truncate(&mut self, len: usize) {
         if len < self.len() {
-            // SAFETY: operation leaves only existing values
             unsafe { self.set_len(len) }
         }
     }

--- a/stylus-sdk/src/storage/vec.rs
+++ b/stylus-sdk/src/storage/vec.rs
@@ -191,7 +191,8 @@ impl<S: StorageType> StorageVec<S> {
     }
 
     /// Removes and returns an accessor to the last element of the vector, if any.
-    pub fn shrink(&mut self) -> Option<StorageGuardMut<'_, S>> {
+    /// Note: this method does not erase any underlying storage, so it is unsafe.
+    pub unsafe fn shrink(&mut self) -> Option<StorageGuardMut<'_, S>> {
         let index = match self.len() {
             0 => return None,
             x => x - 1,


### PR DESCRIPTION
## Description

Mark StorageVec's truncate and shrink as unsafe

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
