### PR TITLE
Errors if solidity keyword is used as a struct name with derive(AbiType)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4680,6 +4680,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4717,11 +4719,9 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "paste",
  "rclite",
- "regex",
  "sha3",
  "stylus-core",
  "stylus-proc",

--- a/examples/abi_decode/Cargo.lock
+++ b/examples/abi_decode/Cargo.lock
@@ -4561,6 +4561,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/abi_encode/Cargo.lock
+++ b/examples/abi_encode/Cargo.lock
@@ -4562,6 +4562,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4578,6 +4580,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4594,10 +4597,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/arrays/Cargo.lock
+++ b/examples/arrays/Cargo.lock
@@ -4561,6 +4561,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/call/Cargo.lock
+++ b/examples/call/Cargo.lock
@@ -4561,6 +4561,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/callee/Cargo.lock
+++ b/examples/callee/Cargo.lock
@@ -4629,6 +4629,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4645,6 +4647,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.104",
  "syn-solidity",
  "trybuild",
@@ -4661,10 +4664,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/caller/Cargo.lock
+++ b/examples/caller/Cargo.lock
@@ -4639,6 +4639,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4655,6 +4657,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.104",
  "syn-solidity",
  "trybuild",
@@ -4671,10 +4674,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/constants/Cargo.lock
+++ b/examples/constants/Cargo.lock
@@ -4561,6 +4561,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/constructor/Cargo.lock
+++ b/examples/constructor/Cargo.lock
@@ -4549,6 +4549,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4565,6 +4567,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4581,10 +4584,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/custom_storage_slots/Cargo.lock
+++ b/examples/custom_storage_slots/Cargo.lock
@@ -4630,6 +4630,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4659,6 +4661,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.104",
  "syn-solidity",
  "trybuild",
@@ -4675,10 +4678,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/delegate_call/Cargo.lock
+++ b/examples/delegate_call/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/encoding_and_hashing/Cargo.lock
+++ b/examples/encoding_and_hashing/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/erc20/Cargo.lock
+++ b/examples/erc20/Cargo.lock
@@ -4540,6 +4540,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4556,6 +4558,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4572,10 +4575,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/erc721/Cargo.lock
+++ b/examples/erc721/Cargo.lock
@@ -4540,6 +4540,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4556,6 +4558,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4572,10 +4575,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/errors/Cargo.lock
+++ b/examples/errors/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/events/Cargo.lock
+++ b/examples/events/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/fallback_receive/Cargo.lock
+++ b/examples/fallback_receive/Cargo.lock
@@ -4547,6 +4547,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4576,6 +4578,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.102",
  "syn-solidity",
  "trybuild",
@@ -4592,10 +4595,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/first_app/Cargo.lock
+++ b/examples/first_app/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/function/Cargo.lock
+++ b/examples/function/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/hello_world/Cargo.lock
+++ b/examples/hello_world/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/inheritance/Cargo.lock
+++ b/examples/inheritance/Cargo.lock
@@ -4727,6 +4727,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4756,6 +4758,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.105",
  "syn-solidity",
  "trybuild",
@@ -4772,10 +4775,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/mapping/Cargo.lock
+++ b/examples/mapping/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/nested_structs/Cargo.lock
+++ b/examples/nested_structs/Cargo.lock
@@ -4547,6 +4547,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4576,6 +4578,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.102",
  "syn-solidity",
  "trybuild",
@@ -4592,10 +4595,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/primitive_data_types/Cargo.lock
+++ b/examples/primitive_data_types/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4577,6 +4579,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4593,10 +4596,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/sending_ether/Cargo.lock
+++ b/examples/sending_ether/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4564,6 +4566,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4580,10 +4583,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/single_call/Cargo.lock
+++ b/examples/single_call/Cargo.lock
@@ -4526,6 +4526,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4542,6 +4544,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4558,10 +4561,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/storage_data_types/Cargo.lock
+++ b/examples/storage_data_types/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4564,6 +4566,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4580,10 +4583,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/test/Cargo.lock
+++ b/examples/test/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4564,6 +4566,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4580,10 +4583,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test 0.10.0-beta.1",

--- a/examples/variables/Cargo.lock
+++ b/examples/variables/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4564,6 +4566,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4580,10 +4583,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/examples/verify_signature/Cargo.lock
+++ b/examples/verify_signature/Cargo.lock
@@ -4548,6 +4548,8 @@ dependencies = [
  "alloy-sol-types",
  "cfg-if",
  "dyn-clone",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -4564,6 +4566,7 @@ dependencies = [
  "quote",
  "regex",
  "sha3",
+ "stylus-core",
  "syn 2.0.101",
  "syn-solidity",
  "trybuild",
@@ -4580,10 +4583,8 @@ dependencies = [
  "derivative",
  "hex",
  "keccak-const",
- "lazy_static",
  "mini-alloc",
  "rclite",
- "regex",
  "stylus-core",
  "stylus-proc",
  "stylus-test",

--- a/stylus-core/Cargo.toml
+++ b/stylus-core/Cargo.toml
@@ -15,6 +15,8 @@ alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 cfg-if.workspace = true
 dyn-clone = "1.0.17"
+regex.workspace = true
+lazy_static.workspace = true
 
 [dev-dependencies]
 

--- a/stylus-core/src/lib.rs
+++ b/stylus-core/src/lib.rs
@@ -8,8 +8,10 @@ extern crate alloc;
 
 pub mod calls;
 pub mod host;
+pub mod sol;
 pub mod storage;
 
 pub use calls::*;
 pub use host::*;
+pub use sol::*;
 pub use storage::TopLevelStorage;

--- a/stylus-core/src/sol.rs
+++ b/stylus-core/src/sol.rs
@@ -1,0 +1,50 @@
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref UINT_REGEX: Regex = Regex::new(r"^uint(\d+)$").unwrap();
+    static ref INT_REGEX: Regex = Regex::new(r"^int(\d+)$").unwrap();
+    static ref BYTES_REGEX: Regex = Regex::new(r"^bytes(\d+)$").unwrap();
+}
+
+pub fn is_sol_keyword(name: &str) -> bool {
+    if let Some(caps) = UINT_REGEX.captures(name) {
+        let bits: usize = caps[1].parse().unwrap();
+        if bits.is_multiple_of(8) {
+            return true;
+        }
+    }
+
+    if let Some(caps) = INT_REGEX.captures(name) {
+        let bits: usize = caps[1].parse().unwrap();
+        if bits.is_multiple_of(8) {
+            return true;
+        }
+    }
+
+    if let Some(caps) = BYTES_REGEX.captures(name) {
+        let bits: usize = caps[1].parse().unwrap();
+        if bits <= 32 {
+            return true;
+        }
+    }
+
+    match name {
+        "" => false,
+
+        // other types
+        "address" | "bytes" | "bool" | "int" | "uint" => true,
+
+        // other words
+        "is" | "contract" | "interface" => true,
+
+        // reserved keywords
+        "after" | "alias" | "apply" | "auto" | "byte" | "case" | "copyof" | "default"
+        | "define" | "final" | "implements" | "in" | "inline" | "let" | "macro" | "match"
+        | "mutable" | "null" | "of" | "partial" | "promise" | "reference" | "relocatable"
+        | "sealed" | "sizeof" | "static" | "supports" | "switch" | "typedef" | "typeof" | "var" => {
+            true
+        }
+        _ => false,
+    }
+}

--- a/stylus-proc/Cargo.toml
+++ b/stylus-proc/Cargo.toml
@@ -24,13 +24,13 @@ sha3.workspace = true
 syn.workspace = true
 syn-solidity.workspace = true
 trybuild.workspace = true
+stylus-core.workspace = true
 
 [dev-dependencies]
 paste.workspace = true
 pretty_assertions.workspace = true
 prettyplease.workspace = true
 stylus-sdk = { workspace = true, features = ["stylus-test"] }
-stylus-core.workspace = true
 
 [features]
 default = ["trybuild-tests"]

--- a/stylus-proc/tests/derive_abi_type.rs
+++ b/stylus-proc/tests/derive_abi_type.rs
@@ -113,4 +113,5 @@ fn decode() {
 fn abi_type_failures() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/fail/derive_abi_type/missing_sol_macro.rs");
+    t.compile_fail("tests/fail/derive_abi_type/keyword_as_struct_name.rs");
 }

--- a/stylus-proc/tests/fail/derive_abi_type/keyword_as_struct_name.rs
+++ b/stylus-proc/tests/fail/derive_abi_type/keyword_as_struct_name.rs
@@ -1,0 +1,14 @@
+// Copyright 2024, Offchain Labs, Inc.
+// For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
+
+//! Compilation will fail if the type is not wrapped in the [`sol!`][alloy_sol_types::sol] macro.
+
+use stylus_proc::AbiType;
+use stylus_sdk::storage::StorageBool;
+
+#[derive(AbiType)]
+struct uint256 {
+    bar: StorageBool,
+}
+
+fn main() {}

--- a/stylus-proc/tests/fail/derive_abi_type/keyword_as_struct_name.stderr
+++ b/stylus-proc/tests/fail/derive_abi_type/keyword_as_struct_name.stderr
@@ -1,0 +1,13 @@
+error: struct name cannot be a Solidity keyword: `uint256`
+  --> tests/fail/derive_abi_type/keyword_as_struct_name.rs:10:8
+   |
+10 | struct uint256 {
+   |        ^^^^^^^
+
+warning: type `uint256` should have an upper camel case name
+  --> tests/fail/derive_abi_type/keyword_as_struct_name.rs:10:8
+   |
+10 | struct uint256 {
+   |        ^^^^^^^ help: convert the identifier to upper camel case (notice the capitalization): `Uint256`
+   |
+   = note: `#[warn(non_camel_case_types)]` on by default

--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -18,10 +18,6 @@ clap.workspace = true
 derivative.workspace = true
 hex = { workspace = true, default-features = false, features = ["alloc"] }
 keccak-const.workspace = true
-lazy_static.workspace = true
-
-# export-abi
-regex = { workspace = true, optional = true }
 
 # local deps
 mini-alloc = { workspace = true, optional = true }
@@ -44,7 +40,7 @@ features = ["default", "docs", "debug", "export-abi", "stylus-test"]
 
 [features]
 default = ["mini-alloc"]
-export-abi = ["debug", "regex", "stylus-proc/export-abi", "alloy-primitives/tiny-keccak"]
+export-abi = ["debug", "stylus-proc/export-abi", "alloy-primitives/tiny-keccak"]
 debug = []
 docs = []
 hostio = []

--- a/stylus-sdk/src/abi/export/mod.rs
+++ b/stylus-sdk/src/abi/export/mod.rs
@@ -10,8 +10,7 @@
 
 use clap::{Parser, Subcommand};
 use core::fmt;
-use lazy_static::lazy_static;
-use regex::Regex;
+use stylus_core;
 
 #[doc(hidden)]
 pub mod internal;
@@ -98,61 +97,13 @@ fn print_constructor_signature<T: GenerateAbi>() {
     print!("{}", AbiPrinter(T::fmt_constructor_signature));
 }
 
-lazy_static! {
-    static ref UINT_REGEX: Regex = Regex::new(r"^uint(\d+)$").unwrap();
-    static ref INT_REGEX: Regex = Regex::new(r"^int(\d+)$").unwrap();
-    static ref BYTES_REGEX: Regex = Regex::new(r"^bytes(\d+)$").unwrap();
-}
-
-pub fn is_sol_keyword(name: &str) -> bool {
-    if let Some(caps) = UINT_REGEX.captures(name) {
-        let bits: usize = caps[1].parse().unwrap();
-        if bits.is_multiple_of(8) {
-            return true;
-        }
-    }
-
-    if let Some(caps) = INT_REGEX.captures(name) {
-        let bits: usize = caps[1].parse().unwrap();
-        if bits.is_multiple_of(8) {
-            return true;
-        }
-    }
-
-    if let Some(caps) = BYTES_REGEX.captures(name) {
-        let bits: usize = caps[1].parse().unwrap();
-        if bits <= 32 {
-            return true;
-        }
-    }
-
-    match name {
-        "" => false,
-
-        // other types
-        "address" | "bytes" | "bool" | "int" | "uint" => true,
-
-        // other words
-        "is" | "contract" | "interface" => true,
-
-        // reserved keywords
-        "after" | "alias" | "apply" | "auto" | "byte" | "case" | "copyof" | "default"
-        | "define" | "final" | "implements" | "in" | "inline" | "let" | "macro" | "match"
-        | "mutable" | "null" | "of" | "partial" | "promise" | "reference" | "relocatable"
-        | "sealed" | "sizeof" | "static" | "supports" | "switch" | "typedef" | "typeof" | "var" => {
-            true
-        }
-        _ => false,
-    }
-}
-
 /// Prepends the string with an underscore if it is a Solidity keyword.
 /// Otherwise, the string is unchanged.
 /// Note: also prepends a space when the input is nonempty.
 pub fn underscore_if_sol(name: &str) -> String {
     let underscore = || format!(" _{name}");
 
-    if is_sol_keyword(name) {
+    if stylus_core::is_sol_keyword(name) {
         return underscore();
     }
 

--- a/stylus-sdk/src/abi/export/mod.rs
+++ b/stylus-sdk/src/abi/export/mod.rs
@@ -104,49 +104,60 @@ lazy_static! {
     static ref BYTES_REGEX: Regex = Regex::new(r"^bytes(\d+)$").unwrap();
 }
 
-/// Prepends the string with an underscore if it is a Solidity keyword.
-/// Otherwise, the string is unchanged.
-/// Note: also prepends a space when the input is nonempty.
-pub fn underscore_if_sol(name: &str) -> String {
-    let underscore = || format!(" _{name}");
-
+pub fn is_sol_keyword(name: &str) -> bool {
     if let Some(caps) = UINT_REGEX.captures(name) {
         let bits: usize = caps[1].parse().unwrap();
         if bits.is_multiple_of(8) {
-            return underscore();
+            return true;
         }
     }
 
     if let Some(caps) = INT_REGEX.captures(name) {
         let bits: usize = caps[1].parse().unwrap();
         if bits.is_multiple_of(8) {
-            return underscore();
+            return true;
         }
     }
 
     if let Some(caps) = BYTES_REGEX.captures(name) {
         let bits: usize = caps[1].parse().unwrap();
         if bits <= 32 {
-            return underscore();
+            return true;
         }
     }
 
     match name {
-        "" => "".to_string(),
+        "" => false,
 
         // other types
-        "address" | "bytes" | "bool" | "int" | "uint" => underscore(),
+        "address" | "bytes" | "bool" | "int" | "uint" => true,
 
         // other words
-        "is" | "contract" | "interface" => underscore(),
+        "is" | "contract" | "interface" => true,
 
         // reserved keywords
         "after" | "alias" | "apply" | "auto" | "byte" | "case" | "copyof" | "default"
         | "define" | "final" | "implements" | "in" | "inline" | "let" | "macro" | "match"
         | "mutable" | "null" | "of" | "partial" | "promise" | "reference" | "relocatable"
         | "sealed" | "sizeof" | "static" | "supports" | "switch" | "typedef" | "typeof" | "var" => {
-            underscore()
+            true
         }
+        _ => false,
+    }
+}
+
+/// Prepends the string with an underscore if it is a Solidity keyword.
+/// Otherwise, the string is unchanged.
+/// Note: also prepends a space when the input is nonempty.
+pub fn underscore_if_sol(name: &str) -> String {
+    let underscore = || format!(" _{name}");
+
+    if is_sol_keyword(name) {
+        return underscore();
+    }
+
+    match name {
+        "" => "".to_string(),
         _ => format!(" {name}"),
     }
 }


### PR DESCRIPTION
## Description

Resolves NIT-3743.

Errors if solidity keyword is used as a struct name with derive(AbiType).

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
