### PR TITLE
Public macro related to trait

### DIFF
--- a/examples/callee/src/lib.rs
+++ b/examples/callee/src/lib.rs
@@ -6,7 +6,6 @@
 extern crate alloc;
 
 use stylus_sdk::{
-    abi::AbiType,
     alloy_primitives::{Address, FixedBytes, U256},
     prelude::*,
     ArbResult,
@@ -24,7 +23,7 @@ impl Callee {
 
 #[public]
 pub trait Trait1<Input1, Input2> {
-    type Output: AbiType;
+    type Output;
     fn one_input_one_output(&self, input: U256) -> Self::Output;
     fn multiple_inputs_multiple_outputs(
         &self,

--- a/examples/callee/src/lib.rs
+++ b/examples/callee/src/lib.rs
@@ -22,6 +22,7 @@ impl Callee {
     fn no_input_no_output(&self) {}
 }
 
+#[public]
 pub trait Trait1<Input1, Input2> {
     type Output: AbiType;
     fn one_input_one_output(&self, input: U256) -> Self::Output;
@@ -63,6 +64,7 @@ impl Trait1<U256, Address> for Callee {
     }
 }
 
+#[public]
 pub trait Trait2 {
     fn outputs_result_ok(&self) -> Result<(U256, U256), Vec<u8>>;
     fn outputs_result_err(&self) -> Result<U256, Vec<u8>>;

--- a/examples/caller/src/lib.rs
+++ b/examples/caller/src/lib.rs
@@ -5,7 +5,7 @@
 
 extern crate alloc;
 
-use callee::{Callee, Trait1ContractClientGen, Trait2ContractClientGen};
+use callee::{Callee, Trait1, Trait2};
 use stylus_sdk::{
     alloy_primitives::{Address, FixedBytes, U256},
     prelude::*,

--- a/examples/erc20/src/ierc20.rs
+++ b/examples/erc20/src/ierc20.rs
@@ -19,6 +19,7 @@ pub enum Erc20Error {
 }
 
 /// Trait that contains the Erc20 token methods.
+#[public]
 pub trait IErc20 {
     /// Immutable token name
     fn name(&self) -> String;

--- a/examples/erc721/src/ierc721.rs
+++ b/examples/erc721/src/ierc721.rs
@@ -30,6 +30,7 @@ pub enum Erc721Error {
 }
 
 // Trait that contains the Erc721 methods.
+#[public]
 pub trait IErc721 {
     /// Immutable NFT name.
     fn name(&self) -> Result<String, Erc721Error>;

--- a/examples/inheritance/src/lib.rs
+++ b/examples/inheritance/src/lib.rs
@@ -15,6 +15,7 @@ use stylus_sdk::{
 // Traits (interfaces)
 // ──────────────────────────────────────────────────────────────────────────────
 
+#[public]
 trait IErc20 {
     fn name(&self) -> String;
     fn symbol(&self) -> String;
@@ -24,6 +25,7 @@ trait IErc20 {
     fn transfer(&mut self, to: Address, value: U256) -> bool;
 }
 
+#[public]
 trait IOwnable {
     fn owner(&self) -> Address;
     fn transfer_ownership(&mut self, new_owner: Address) -> bool;
@@ -32,6 +34,7 @@ trait IOwnable {
 
 // Extra trait with a “name-like” concept we also want to export.
 // We'll give it a distinct Solidity-visible selector to avoid clobbering ERC-20's `name()`.
+#[public]
 trait IBranding {
     fn brand_name(&self) -> String;
 }

--- a/stylus-proc/src/macros/public/export_abi.rs
+++ b/stylus-proc/src/macros/public/export_abi.rs
@@ -141,7 +141,7 @@ impl InterfaceExtension for InterfaceAbi {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct FnAbi {
     pub output: Option<syn::Type>,
 }

--- a/stylus-proc/src/macros/public/mod.rs
+++ b/stylus-proc/src/macros/public/mod.rs
@@ -117,7 +117,7 @@ impl From<&mut syn::ItemTrait> for PublicTrait {
         let mut associated_types = Vec::new();
         for item in &node.items {
             if let syn::TraitItem::Type(type_item) = item {
-                associated_types.push(type_item.ident.clone());
+                associated_types.push((type_item.ident.clone(), type_item.bounds.clone()));
             }
         }
 

--- a/stylus-proc/src/macros/public/mod.rs
+++ b/stylus-proc/src/macros/public/mod.rs
@@ -54,7 +54,11 @@ pub fn public(attr: TokenStream, input: TokenStream) -> TokenStream {
             public_impl.to_tokens(&mut output);
         }
         syn::Item::Trait(mut item_trait) => {
-            let public_trait = PublicTrait::from(&mut item_trait);
+            let _public_trait = PublicTrait::from(&mut item_trait);
+            output.extend(quote! {
+                #[cfg(not(feature = "contract-client-gen"))]
+            });
+            output.extend(item_trait.into_token_stream());
         }
         _ => {
             emit_error!(item.span(), "expected impl or trait");

--- a/stylus-proc/src/macros/public/types.rs
+++ b/stylus-proc/src/macros/public/types.rs
@@ -59,10 +59,14 @@ pub struct PublicImpl<E: InterfaceExtension = Extension> {
     pub extension: E,
 }
 
-pub struct PublicTrait {
+pub struct PublicTrait<E: InterfaceExtension = Extension> {
+    #[allow(dead_code)]
     pub generic_params: Punctuated<syn::GenericParam, Token![,]>,
+    #[allow(dead_code)]
     pub where_clause: Punctuated<syn::WherePredicate, Token![,]>,
+    #[allow(dead_code)]
     pub funcs: Vec<PublicFn<E::FnExt>>,
+    #[allow(dead_code)]
     pub associated_types: Vec<syn::Ident>,
 }
 

--- a/stylus-proc/src/macros/public/types.rs
+++ b/stylus-proc/src/macros/public/types.rs
@@ -59,6 +59,13 @@ pub struct PublicImpl<E: InterfaceExtension = Extension> {
     pub extension: E,
 }
 
+pub struct PublicTrait {
+    pub generic_params: Punctuated<syn::GenericParam, Token![,]>,
+    pub where_clause: Punctuated<syn::WherePredicate, Token![,]>,
+    pub funcs: Vec<PublicFn<E::FnExt>>,
+    pub associated_types: Vec<syn::Ident>,
+}
+
 fn get_default_output(ty: &syn::Type) -> (TokenStream, TokenStream) {
     (
         quote! {

--- a/stylus-proc/src/macros/public/types.rs
+++ b/stylus-proc/src/macros/public/types.rs
@@ -79,7 +79,7 @@ fn get_default_output(ty: &syn::Type) -> (TokenStream, TokenStream) {
 }
 
 fn get_client_funcs<E: InterfaceExtension>(
-    funcs: &Vec<PublicFn<E::FnExt>>,
+    funcs: &[PublicFn<E::FnExt>],
     public: bool,
 ) -> (Vec<proc_macro2::TokenStream>, Vec<proc_macro2::TokenStream>) {
     let (client_funcs_definitions, client_funcs_declarations): (
@@ -390,7 +390,8 @@ impl PublicImpl {
     }
 
     pub fn contract_client_gen(&self) -> proc_macro2::TokenStream {
-        let (client_funcs_definitions, _) = get_client_funcs::<Extension>(&self.funcs, !self.trait_.is_some());
+        let (client_funcs_definitions, _) =
+            get_client_funcs::<Extension>(&self.funcs, self.trait_.is_none());
 
         let associated_types_definitions: Vec<proc_macro2::TokenStream> = self
             .associated_types

--- a/stylus-proc/src/types.rs
+++ b/stylus-proc/src/types.rs
@@ -19,8 +19,8 @@ pub enum Purity {
 impl Purity {
     /// Infer the purity of the function by inspecting the first argument. Also returns whether the
     /// function has a self parameter.
-    pub fn infer(func: &syn::ImplItemFn) -> (Self, bool) {
-        match func.sig.inputs.first() {
+    pub fn infer(sig: &syn::Signature) -> (Self, bool) {
+        match sig.inputs.first() {
             Some(syn::FnArg::Receiver(recv)) => (recv.mutability.into(), true),
             Some(syn::FnArg::Typed(syn::PatType { ty, .. })) => match &**ty {
                 syn::Type::Reference(ty) => (ty.mutability.into(), false),

--- a/stylus-proc/src/utils/mod.rs
+++ b/stylus-proc/src/utils/mod.rs
@@ -12,26 +12,19 @@ pub mod attrs;
 #[cfg(test)]
 pub mod testing;
 
-/// Like [`syn::Generics::split_for_impl`] but for [`syn::ItemImpl`].
-///
-/// [`syn::Generics::split_for_impl`] does not work in this case because the `name` of the
-/// implemented type is not easy to get, but the type including generics is.
-pub fn split_item_impl_for_impl(
-    node: &syn::ItemImpl,
+pub fn get_generics(
+    generics: &syn::Generics,
 ) -> (
     Punctuated<syn::GenericParam, Token![,]>,
-    syn::Type,
     Punctuated<syn::WherePredicate, Token![,]>,
 ) {
-    let generic_params = node.generics.params.clone();
-    let self_ty = (*node.self_ty).clone();
-    let where_clause = node
-        .generics
+    let generic_params = generics.params.clone();
+    let where_clause = generics
         .where_clause
         .clone()
         .map(|c| c.predicates)
         .unwrap_or_default();
-    (generic_params, self_ty, where_clause)
+    (generic_params, where_clause)
 }
 
 /// Build [function selector](https://solidity-by-example.org/function-selector/) byte array.

--- a/stylus-proc/tests/fail/public/missing_macros.rs
+++ b/stylus-proc/tests/fail/public/missing_macros.rs
@@ -1,0 +1,60 @@
+// Copyright 2025, Offchain Labs, Inc.
+// For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
+
+extern crate alloc;
+
+use stylus_sdk::{
+    alloy_primitives::{Address, U256},
+    prelude::*,
+};
+
+#[storage]
+#[entrypoint]
+pub struct Contract {}
+
+#[public]
+#[implements(Trait1)]
+impl Contract {}
+
+// Missing #[public] attribute on trait methods
+pub trait Trait1 {
+    fn trait1_fn1(&self, _input: U256) -> U256;
+}
+
+#[public]
+impl Trait1 for Contract {
+    fn trait1_fn1(&self, _input: U256) -> U256 {
+        todo!()
+    }
+}
+
+#[public]
+pub trait Trait2 {
+    fn trait2_fn1(&self, _input: U256) -> U256;
+    fn trait2_fn2(&mut self, _to: Address, _value: U256) -> bool;
+}
+
+#[public]
+impl Trait2 for Contract {
+    fn trait2_fn1(&self, _input: U256) -> U256 {
+        todo!()
+    }
+
+    fn trait2_fn2(&mut self, _to: Address, _value: U256) -> bool {
+        todo!()
+    }
+}
+
+#[public]
+pub trait Trait3 {
+    fn trait3_fn1(&self, _input: U256) -> U256;
+}
+
+// Missing #[public] attribute on impl block
+impl Trait3 for Contract {
+    fn trait3_fn1(&self, _input: U256) -> U256 {
+        todo!()
+    }
+}
+
+fn main() {}

--- a/stylus-proc/tests/fail/public/missing_macros.stderr
+++ b/stylus-proc/tests/fail/public/missing_macros.stderr
@@ -1,0 +1,16 @@
+error[E0407]: method `__stylus_trait_and_impl_must_be_tagged_with_public_macro` is not a member of trait `Trait1`
+  --> tests/fail/public/missing_macros.rs:24:1
+   |
+24 | #[public]
+   | ^^^^^^^^^ not a member of trait `Trait1`
+   |
+   = note: this error originates in the attribute macro `public` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0046]: not all trait items implemented, missing: `__stylus_trait_and_impl_must_be_tagged_with_public_macro`
+  --> tests/fail/public/missing_macros.rs:54:1
+   |
+48 | #[public]
+   | --------- `__stylus_trait_and_impl_must_be_tagged_with_public_macro` from trait
+...
+54 | impl Trait3 for Contract {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^ missing `__stylus_trait_and_impl_must_be_tagged_with_public_macro` in implementation

--- a/stylus-proc/tests/parameterized_trait_with_associated_types.rs
+++ b/stylus-proc/tests/parameterized_trait_with_associated_types.rs
@@ -7,6 +7,7 @@
 
 #![allow(dead_code)]
 #![allow(unused_variables)]
+#![allow(unused_imports)]
 
 extern crate alloc;
 
@@ -21,6 +22,7 @@ pub struct Contract {}
 #[implements(MyTrait<u32, u32, Output = u32>)]
 impl Contract {}
 
+#[public]
 pub trait MyTrait<Input1, Input2> {
     type Output: AbiType;
     fn foo(&self, input1: Input1, input2: Input2) -> Self::Output;

--- a/stylus-proc/tests/public.rs
+++ b/stylus-proc/tests/public.rs
@@ -54,4 +54,5 @@ fn test_public_failures() {
     t.compile_fail("tests/fail/public/generated.rs");
     t.compile_fail("tests/fail/public/macro_errors.rs");
     t.compile_fail("tests/fail/public/constructor.rs");
+    t.compile_fail("tests/fail/public/missing_macros.rs");
 }

--- a/stylus-proc/tests/public_composition.rs
+++ b/stylus-proc/tests/public_composition.rs
@@ -33,6 +33,7 @@ struct Erc20 {
     total_supply: StorageU256,
 }
 
+#[public]
 trait IErc20 {
     fn name(&self) -> String;
     fn symbol(&self) -> String;
@@ -72,6 +73,7 @@ struct Ownable {
     owner: StorageAddress,
 }
 
+#[public]
 trait IOwnable {
     fn owner(&self) -> Address;
     fn transfer_ownership(&mut self, new_owner: Address) -> bool;
@@ -91,6 +93,7 @@ impl IOwnable for Contract {
     }
 }
 
+#[public]
 trait PureTrait {
     fn pure_method()
     where


### PR DESCRIPTION
## Description

Resolves NIT-3844

This PR proposes that the #[public] macro becomes a requirement for pub traits implemented by the entrypoint struct.

This will enable to: 
- Enforce that pub traits have associated types bounded to AbiType, [here](https://github.com/OffchainLabs/stylus-sdk-rs/blob/9e514963d0931257c09219e5d98a205f79b979b7/examples/callee/src/lib.rs#L26) is an example.
- Overwrite the pub trait in case the contract-client-gen feature is provided. Today caller contracts need to import generated traits, such as [Trait1ContractClientGen](https://github.com/OffchainLabs/stylus-sdk-rs/blob/9e514963d0931257c09219e5d98a205f79b979b7/examples/caller/src/lib.rs#L8,), that don't have the same name as the original pub trait, Trait1 in this example. By overwriting the pub trait, the caller contract will be able to import Trait1 instead of Trait1ContractClientGen.

In order to enforce that pub traits implemented by the entrypoint struct are tagged with a #[public] macro, when the #[public] macro is applied to an impl, such as `impl Trait1 for Callee`, it will include a dummy function, such as `__stylus_trait_and_impl_must_be_tagged_with_public_macro()`. When applied to a pub trait, the #[public] will add this function signature to the trait. So if an user forgets to add the #[public] macro to the pub trait a build error will be generated, such as `fn __stylus_trait_and_impl_must_be_tagged_with_public_macro is not a member of trait Trait1`. An user could "hack" this, and add `__stylus_trait_and_impl_must_be_tagged_with_public_macro()` directly to the pub trait though.

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
