### PR TITLE
Keccak native

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/OffchainLabs/stylus-sdk-rs"
 rust-version = "1.71.0"
 
 [workspace.dependencies]
-alloy-primitives = { version = "=0.8.20", default-features = false , features = ["native-keccak"] }
+alloy-primitives = { version = "=0.8.20", default-features = false }
 alloy-sol-types = { version = "=0.8.20", default-features = false }
 cfg-if = "1.0.0"
 clap = { version = "4.5.4", features = [ "derive", "color" ] }

--- a/stylus-core/Cargo.toml
+++ b/stylus-core/Cargo.toml
@@ -16,6 +16,9 @@ alloy-sol-types.workspace = true
 cfg-if.workspace = true
 dyn-clone = "1.0.17"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+alloy-primitives = { version = "=0.8.20", default-features = false , features = ["native-keccak"] }
+
 [dev-dependencies]
 
 [features]

--- a/stylus-proc/Cargo.toml
+++ b/stylus-proc/Cargo.toml
@@ -25,6 +25,9 @@ syn.workspace = true
 syn-solidity.workspace = true
 trybuild.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+alloy-primitives = { version = "=0.8.20", default-features = false , features = ["native-keccak"] }
+
 [dev-dependencies]
 paste.workspace = true
 pretty_assertions.workspace = true

--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -28,6 +28,9 @@ mini-alloc = { workspace = true, optional = true }
 stylus-proc.workspace = true
 stylus-core.workspace = true
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+alloy-primitives = { version = "=0.8.20", default-features = false , features = ["native-keccak"] }
+
 # Ensure these dependencies won't be included in wasm32 target
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rclite = { workspace = true, optional = true }

--- a/stylus-test/Cargo.toml
+++ b/stylus-test/Cargo.toml
@@ -18,6 +18,9 @@ tokio = { version = "1.12.0", features = ["full"] }
 alloy-provider = "0.11.0"
 url = "2.5.4"
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+alloy-primitives = { version = "=0.8.20", default-features = false , features = ["native-keccak"] }
+
 [dev-dependencies]
 
 [features]


### PR DESCRIPTION
## Description

Only use `native-keccak` feature for wasm32 build.

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
