### PR TITLE
add MethodError implementation for SolError derive macro

### DIFF
--- a/stylus-proc/src/macros/derive/solidity_error/mod.rs
+++ b/stylus-proc/src/macros/derive/solidity_error/mod.rs
@@ -70,6 +70,17 @@ impl DeriveSolidityError {
             }
         }
     }
+
+    fn method_error_impl(&self) -> syn::ItemImpl {
+        let name = &self.name;
+        parse_quote! {
+            impl stylus_sdk::stylus_core::errors::MethodError for #name {
+                fn encode(self) -> alloc::vec::Vec<u8> {
+                    self.into()
+                }
+            }
+        }
+    }
 }
 
 impl From<&syn::ItemEnum> for DeriveSolidityError {
@@ -101,6 +112,7 @@ impl ToTokens for DeriveSolidityError {
             from_impl.to_tokens(tokens);
         }
         self.vec_u8_from_impl().to_tokens(tokens);
+        self.method_error_impl().to_tokens(tokens);
         Extension::codegen(self).to_tokens(tokens);
     }
 }
@@ -160,5 +172,13 @@ mod tests {
                 }
             },
         );
+        assert_ast_eq(
+            derived.method_error_impl(),
+            parse_quote!{
+                impl stylus_sdk::stylus_core::errors::MethodError for MyError {
+                    fn encode(self) -> alloc::vec::Vec<u8> { self.into() }
+                }
+            }
+        )
     }
 }


### PR DESCRIPTION
## Description

Adds implementation of `stylus_sdk::call::MethodError` trait inside `SolidityError` macro.
MethodError trait is necessary for error types inside `SolidityError` enum.
By the end it will be possible to nest error like this:

```rust
#[derive(SolidityError, Debug)]
pub enum Error {
    Erc721(erc721::Error),
    Checkpoint(checkpoints::Error),
    ForbiddenBatchMint(ERC721ForbiddenBatchMint),
    ExceededMaxBatchMint(ERC721ExceededMaxBatchMint),
    ForbiddenMint(ERC721ForbiddenMint),
    ForbiddenBatchBurn(ERC721ForbiddenBatchBurn),
}
```

Resolves #135

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
