### PR TITLE
Afilios/nit 3673 incorrect data location for constructors arguments

### DIFF
--- a/cargo-stylus/tests/commands.rs
+++ b/cargo-stylus/tests/commands.rs
@@ -7,7 +7,7 @@ fn test_constructor_cmd() {
         .arg("constructor")
         .assert()
         .success()
-        .stdout("constructor(uint256 initial_number, string calldata _b) payable\n");
+        .stdout("constructor(uint256 initial_number, string memory _b) payable\n");
 }
 
 #[test]

--- a/stylus-proc/src/macros/public/export_abi.rs
+++ b/stylus-proc/src/macros/public/export_abi.rs
@@ -95,7 +95,7 @@ impl InterfaceExtension for InterfaceAbi {
                         let name = arg.extension.pattern_ident.as_ref().map(ToString::to_string).unwrap_or_default();
                         let ty = &arg.ty;
                         quote! {
-                            write!(f, "{}{}{}", #comma, <#ty as AbiType>::EXPORT_ABI_ARG, underscore_if_sol(#name))?;
+                            write!(f, "{}{}{}", #comma, <#ty as AbiType>::EXPORT_ABI_RET, underscore_if_sol(#name))?;
                         }
                     });
                     let sol_purity = match func.purity {

--- a/stylus-proc/tests/contract_abi.rs
+++ b/stylus-proc/tests/contract_abi.rs
@@ -9,7 +9,7 @@ fn test_constructor_cmd() {
         .arg("constructor")
         .assert()
         .success()
-        .stdout("constructor(uint256 initial_number, string calldata _b) payable\n");
+        .stdout("constructor(uint256 initial_number, string memory _b) payable\n");
 }
 
 #[test]


### PR DESCRIPTION
## Description

Please provide a summary of the changes and any backward incompatibilities.

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
