### PR TITLE
Fix stylus replay `not implemented` panic

### DIFF
--- a/cargo-stylus/src/common_args.rs
+++ b/cargo-stylus/src/common_args.rs
@@ -246,6 +246,9 @@ pub struct TraceArgs {
     /// Tx to replay.
     #[arg(short, long)]
     pub tx: TxHash,
+    /// Project path.
+    #[arg(short, long, default_value = ".")]
+    pub project: PathBuf,
 
     #[command(flatten)]
     pub config: TraceConfig,

--- a/stylus-tools/src/utils/sys.rs
+++ b/stylus-tools/src/utils/sys.rs
@@ -10,6 +10,12 @@ use std::{
     process::{Command, Stdio},
 };
 
+pub fn new_command<S: AsRef<OsStr>>(program: S) -> Command {
+    let mut command = Command::new(program);
+    command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    command
+}
+
 pub fn command_exists(program: impl AsRef<OsStr>) -> bool {
     Command::new(program)
         .stdout(Stdio::null())


### PR DESCRIPTION
fixes [NIT-4053](https://github.com/OffchainLabs/stylus-sdk-rs/pull/366#issue-3551229847)

## Description

When running stylus replay with latest main branch we get the following panic:
```
Process 44175 resuming

thread '<unnamed>' panicked at /Users/user/repos/stylus/stylus-sdk-rs/stylus-sdk/src/hostio.rs:60:1:
not implemented
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread '<unnamed>' panicked at library/core/src/panicking.rs:218:5:
panic in a function that cannot unwind
stack backtrace:
   0:        0x100f75c20 - std::backtrace_rs::backtrace::libunwind::trace::hd09570c029a6744a
              at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/../../backtrace/src/backtrace/libunwind.rs:117:9
   1:        0x100f75c20 - std::backtrace_rs::backtrace::trace_unsynchronized::h8d2fa64833f91cb3
                    at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/../../backtrace/src/backtrace/mod.rs:66:14
100f75c20 - std::sys::backtrace::_print_fmt::h567d2a106a3b0dee
                        at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/sys/backtrace.rs:66:9
h92dda645f072dcaf
39:26
::hc0b28dad2d7b7ba8
                               at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/fmt/rt.rs:184:76
::hbc92919d8e8f9a96

   6:        0x100f74684 - std::io::default_write_fmt::h0768ab719ca8b5cc
                               at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/io/mod.rs:639:11
   7:        0x100f74684 - std::io::Write::write_fmt::hcee3b5dc9ab531be
                    at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/io/mod.rs:1914:13
   8:        0x100f75ad4 - std::sys::backtrace::BacktraceLock::print::h0f497abce563e5d2
                          at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/sys/backtrace.rs:42:9
   9:        0x100f7683c - std::panicking::default_hook::{{closure}}::h62595143a6c21f05
                               at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/panicking.rs:300:22
  10:        0x100f7668c - std::panicking::default_hook::hd800536ed1df5085
                               at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/panicking.rs:327:9
100f7724c - std::panicking::rust_panic_with_hook::h1882a30575fbb763
               at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/panicking.rs:833:13

                               at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/panicking.rs:699:13
h6ede323c05a76849
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/sys/backtrace.rs:168:18
  14:        0x100f76bf0 - __rustc[95feac21a9532783]::rust_begin_unwind
                               at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/std/src/panicking.rs:697:5
  15:        0x100f8dbfc - core::panicking::panic_nounwind_fmt::runtime::hcbc23776d9f6f115
                               at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/panicking.rs:117:22
    0x100f8dbfc - core::panicking::panic_nounwind_fmt::hae736249e48cf020
                at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/intrinsics/mod.rs:3241:9
       0x100f8dc74 - core::panicking::panic_nounwind::hb89b2a5de4429251
                           at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/panicking.rs:218:5
  18:        0x100f8dd50 - core::panicking::panic_cannot_unwind::h620b5c02cb97e1cc
                               at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library/core/src/panicking.rs:323:5
  19:        0x100f4c908 - user_entrypoint
:5
  20:        0x10006c464 - cargo_stylus_beta::commands::exec::{{closure}}::h0949db14a3be671c
  21:        0x1000878f8 - tokio::runtime::runtime::Runtime::block_on::h46962bd56e050b3c
  22:        0x1000e4ab4 - cargo_stylus_beta::main::h7326f5023be699ca
  23:        0x10011ce84 - std::sys::backtrace::__rust_begin_short_backtrace::h807be22a7a8703d2
rt::lang_start::{{closure}}::h481322c7023e983c
  25:        0x10069af18 - std::rt::lang_start_internal::hdb28e94b6865fa11
26:        0x1000f580c - _main
thread caused non-unwinding panic. aborting
```

Every time we run cargo stylus deploy we build a shared lib for the contract in question. Such shared library is reused by `replay` to feed into lldb. The problem is that version of the shared library uses `export-abi` and whe rust unwraps `vm_hooks` macro we get the following contract stubs:
```
mod vm_hooks {
...
#[allow(unused_variables, clippy::missing_safety_doc)]
pub fn account_balance(address: *const u8, dest: *mut u8) {
    unimplemented!()
}
...
```
To fix we bring `build_shared_library` from [here](https://github.com/OffchainLabs/cargo-stylus/blob/main/main/src/main.rs#L852-L875) so that `replay` rebuilds the shared lib without `export-abi` and properly create the external libs necessary for lldb debug.

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
