### PR TITLE
368 generated abi missing data location when return param is struct type

### DIFF
--- a/cargo-stylus/tests/commands.rs
+++ b/cargo-stylus/tests/commands.rs
@@ -38,7 +38,7 @@ interface ICounter is ITrait1, ITrait2 {
 
     function mixed(MixedInput input) external;
 
-    function mixedResult() external view returns (MixedResult);
+    function mixedResult() external view returns (MixedResult memory);
 
     struct MixedResult {uint256 number;string text;uint256 number2;}
 }

--- a/examples/nested_structs/abi.sol
+++ b/examples/nested_structs/abi.sol
@@ -11,7 +11,7 @@ interface INestedStructs {
 
     function addDogs(address user, Dog[] memory dogs) external;
 
-    function getUser(address _address) external view returns (User);
+    function getUser(address _address) external view returns (User memory);
 
     function getAllUsers() external view returns (User[] memory);
 

--- a/examples/nested_structs/tests/nested_structs_integration_test.rs
+++ b/examples/nested_structs/tests/nested_structs_integration_test.rs
@@ -13,7 +13,7 @@ mod integration_test {
         interface INestedStructs  {
             function addUser(address _address, string calldata name) external;
             function addDogs(address user, Dog[] memory dogs) external;
-            function getUser(address _address) external view returns (User);
+            function getUser(address _address) external view returns (User memory);
             function getAllUsers() external view returns (User[] memory);
             error NotFound();
             error AlreadyExists();
@@ -33,7 +33,7 @@ interface INestedStructs {
 
     function addDogs(address user, Dog[] memory dogs) external;
 
-    function getUser(address _address) external view returns (User);
+    function getUser(address _address) external view returns (User memory);
 
     function getAllUsers() external view returns (User[] memory);
 

--- a/stylus-proc/src/macros/derive/abi_type/mod.rs
+++ b/stylus-proc/src/macros/derive/abi_type/mod.rs
@@ -73,6 +73,8 @@ impl<E: DeriveAbiTypeExtension> DeriveAbiTypeGenerator<E> {
                         .concat(#fields_selector_abis)
                     )*
                     .concat(#ConstString::new(")"));
+
+                const EXPORT_ABI_RET: #ConstString = Self::ABI.concat(#ConstString::new(" memory"));
             }
         }
     }
@@ -136,6 +138,8 @@ mod tests {
                     .concat(stylus_sdk::abi::ConstString::new(","))
                     .concat(<T as stylus_sdk::abi::AbiType>::SELECTOR_ABI)
                     .concat(stylus_sdk::abi::ConstString::new(")"));
+                const EXPORT_ABI_RET: stylus_sdk::abi::ConstString = Self::ABI
+                    .concat(stylus_sdk::abi::ConstString::new(" memory"));
             }
         };
         assert_ast_eq(result, expected);

--- a/stylus-proc/tests/contract_abi.rs
+++ b/stylus-proc/tests/contract_abi.rs
@@ -42,7 +42,7 @@ interface ICounter is ITrait1, ITrait2 {
 
     function mixed(MixedInput input) external;
 
-    function mixedResult() external view returns (MixedResult);
+    function mixedResult() external view returns (MixedResult memory);
 
     struct MixedResult {uint256 number;string text;uint256 number2;}
 }


### PR DESCRIPTION
## Description

Fix for issue #368 

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
