### PR TITLE
debug: Fix multi-contract debugging

### DIFF
--- a/cargo-stylus/src/commands/debug_hook.rs
+++ b/cargo-stylus/src/commands/debug_hook.rs
@@ -1,6 +1,12 @@
 // Copyright 2025, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
 
+//! Debugger hook infrastructure for Stylus contract debugging.
+//!
+//! This module provides hooks for debugger integration, including support for
+//! cross-contract context switching. Some methods are scaffolded for future
+//! Solidity interop debugging support.
+
 use eyre::Result;
 use parking_lot::Mutex;
 use std::io::Write;
@@ -8,7 +14,11 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::sync::Arc;
 
-/// Interface for debugger hooks to receive execution events
+/// Interface for debugger hooks to receive execution events.
+///
+/// Note: `on_external_call` and `on_return_from_call` are reserved for future
+/// Stylus <-> Solidity interop debugging support.
+#[allow(dead_code)]
 pub trait DebuggerHook: Send + Sync {
     /// Called when execution enters an external contract
     fn on_external_call(&self, contract_address: &str);
@@ -24,6 +34,7 @@ pub trait DebuggerHook: Send + Sync {
 }
 
 /// No-op implementation for when no debugger is attached
+#[allow(dead_code)]
 pub struct NoOpDebuggerHook;
 
 impl DebuggerHook for NoOpDebuggerHook {
@@ -33,7 +44,12 @@ impl DebuggerHook for NoOpDebuggerHook {
     fn on_contract_info(&self, _contract_address: &str, _is_solidity: bool) {}
 }
 
-/// Stylus debugger hook that communicates via Unix socket
+/// Stylus debugger hook that communicates via Unix socket.
+///
+/// TODO: Windows is not currently a target for stylusdb-based debugging.
+/// This implementation uses Unix sockets and Unix-specific paths (/tmp/).
+/// Windows support would require either Windows Subsystem for Linux (WSL)
+/// or a platform-specific implementation using named pipes.
 pub struct StylusDebuggerHook {
     socket_path: String,
     connection: Arc<Mutex<Option<UnixStream>>>,
@@ -41,6 +57,7 @@ pub struct StylusDebuggerHook {
 
 impl StylusDebuggerHook {
     pub fn new() -> Result<Self> {
+        // Note: Unix-specific path format; not supported on Windows without WSL
         let socket_path = format!("/tmp/stylus_debug_{}.sock", std::process::id());
 
         // Start listener in background
@@ -70,7 +87,9 @@ impl StylusDebuggerHook {
         if let Ok((_stream, _)) = listener.accept() {
             println!("Debugger connected via socket");
             // Store connection for later use
-            // TODO: pass this back
+            // TODO: Pass the stream back to store in self.connection.
+            // This will be needed when Solidity interop debugging is added,
+            // enabling real-time context switching between Stylus and Solidity contracts.
         }
 
         Ok(())
@@ -125,7 +144,9 @@ pub fn init_debugger_hook(hook: Arc<dyn DebuggerHook>) {
     *guard = Some(hook);
 }
 
-/// Get the current debugger hook
+/// Get the current debugger hook.
+/// Reserved for future Solidity interop debugging support.
+#[allow(dead_code)]
 pub fn get_debugger_hook() -> Option<Arc<dyn DebuggerHook>> {
     DEBUGGER_HOOK.lock().clone()
 }

--- a/cargo-stylus/src/commands/mod.rs
+++ b/cargo-stylus/src/commands/mod.rs
@@ -80,10 +80,10 @@ pub async fn exec(cmd: Command) -> CargoStylusResult {
         Command::GetInitcode(args) => get_initcode::exec(args),
         Command::Init(args) => init::exec(args),
         Command::New(args) => new::exec(args),
-        Command::Replay(args) => replay::exec(args).await.map_err(Into::into),
+        Command::Replay(args) => replay::exec(args).await,
         Command::Simulate(args) => simulate::exec(args).await,
         Command::Trace(args) => trace::exec(args).await,
-        Command::Usertrace(args) => usertrace::exec(args).await.map_err(Into::into),
+        Command::Usertrace(args) => usertrace::exec(args).await,
         Command::Verify(args) => verify::exec(args).await,
     }
 }

--- a/cargo-stylus/src/utils/hostio.rs
+++ b/cargo-stylus/src/utils/hostio.rs
@@ -448,6 +448,21 @@ pub unsafe extern "C" fn call_contract(
     assert_eq!(read_bytes(calldata, calldata_len), &*data);
     assert_eq!(read_fixed(value_ptr), value.to_be_bytes::<32>());
     assert_eq!(gas_supplied, gas);
+
+    // Check if we should dispatch to an external contract for multi-contract debugging
+    if let Some(access) = EXTERNAL_CONTRACT_ACCESS.lock().as_ref() {
+        let input_data = read_bytes(calldata, calldata_len);
+
+        enter_external_contract();
+        let result = access.call_external_contract(&address, &input_data);
+        exit_external_contract();
+
+        if let Ok((ext_status, _ext_data)) = result {
+            *return_data_len = outs_len;
+            return ext_status;
+        }
+    }
+
     *return_data_len = outs_len;
     status
 }
@@ -496,6 +511,21 @@ pub unsafe extern "C" fn delegate_call_contract(
     assert_eq!(read_fixed(address_ptr), address);
     assert_eq!(read_bytes(calldata, calldata_len), &*data);
     assert_eq!(gas_supplied, gas);
+
+    // Check if we should dispatch to an external contract for multi-contract debugging
+    if let Some(access) = EXTERNAL_CONTRACT_ACCESS.lock().as_ref() {
+        let input_data = read_bytes(calldata, calldata_len);
+
+        enter_external_contract();
+        let result = access.call_external_contract(&address, &input_data);
+        exit_external_contract();
+
+        if let Ok((ext_status, _ext_data)) = result {
+            *return_data_len = outs_len;
+            return ext_status;
+        }
+    }
+
     *return_data_len = outs_len;
     status
 }
@@ -543,6 +573,21 @@ pub unsafe extern "C" fn static_call_contract(
     assert_eq!(read_fixed(address_ptr), address);
     assert_eq!(read_bytes(calldata, calldata_len), &*data);
     assert_eq!(gas_supplied, gas);
+
+    // Check if we should dispatch to an external contract for multi-contract debugging
+    if let Some(access) = EXTERNAL_CONTRACT_ACCESS.lock().as_ref() {
+        let input_data = read_bytes(calldata, calldata_len);
+
+        enter_external_contract();
+        let result = access.call_external_contract(&address, &input_data);
+        exit_external_contract();
+
+        if let Ok((ext_status, _ext_data)) = result {
+            *return_data_len = outs_len;
+            return ext_status;
+        }
+    }
+
     *return_data_len = outs_len;
     status
 }


### PR DESCRIPTION
In addition to that, fix:

  - Add TODO for Windows support related to StylusDebuggerHook
  - Use CargoStylusResult for usertrace and replay
  - Improve TODOs with clear explanation in debug_hook that will be used in rust <--> solidity debugging
  - Fix error messages not to use .so only
  - Add 'struct LoadedLibrary' - represents loaded shared library with its path for debug symbols
  - Remove stable_rust flag from usertrace and replay
  - Fixed misleading error messages for replay --contracts
