### PR TITLE
Add AssemblyScript SDK to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ The Stylus VM supports more than just Rust. In fact, any programming language th
 |:-----------------|:----------------------------|:------------------|
 | [Rust SDK][Rust] | Everything!                 | Apache 2.0 or MIT |
 | [C/C++ SDK][C]   | Cryptography and algorithms | Apache 2.0 or MIT |
-| [AssemblyScript SDK][AssemblyScript] | Educational | Apache 2.0 or MIT |
+| [AssemblyScript SDK][AssemblyScript]* | Educational | Apache 2.0 or MIT |
 | [Bf SDK][Bf]     | Educational                 | Apache 2.0 or MIT |
 | [Cargo Stylus][CargoStylus]     | Deploying Stylus programs | Apache 2.0 or MIT |
 
 Want to write your own? [Join us in the `#stylus` channel on discord][discord]!
+
+_*This SDK is developed and maintained by an independent team._
 
 [Rust]: https://github.com/OffchainLabs/stylus-sdk-rs
 [C]: https://github.com/OffchainLabs/stylus-sdk-c


### PR DESCRIPTION
## Description

Add link to the AssemblyScript SDK (TypeScript/AssemblyScript) to the "Don't know Rust?" section of the README.

This adds a reference to the AssemblyScript SDK developed by Wakeup Labs, which enables developers to write Arbitrum Stylus smart contracts using TypeScript and AssemblyScript.

Repository: https://github.com/wakeuplabs-io/assembly-script-stylus-sdk

## Checklist

- [X] I have documented these changes where necessary.
- [X] I have read the [DCO][DCO] and ensured that these changes comply.
- [X] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
