### PR TITLE
Enable debugging for linux

### DIFF
--- a/cargo-stylus/build.rs
+++ b/cargo-stylus/build.rs
@@ -1,0 +1,72 @@
+fn main() {
+    // On Linux, export hostio symbols to the dynamic symbol table so that
+    // contract shared libraries loaded via dlopen() can resolve them from
+    // the cargo-stylus binary at runtime.
+    //
+    // This is the Linux equivalent of macOS's -undefined dynamic_lookup
+    // linker flag. On macOS, the contract .dylib is built with that flag
+    // so unresolved symbols are looked up at load time. On Linux, shared
+    // libraries already allow undefined symbols by default, but the host
+    // binary must explicitly export its symbols for dlopen'd libraries to
+    // find them.
+    //
+    // We use --export-dynamic-symbol for each hostio function rather than
+    // -rdynamic (which exports ALL symbols) to avoid pulling in unrelated
+    // symbols that cause linker errors (e.g. wasmer_vm's __rust_probestack).
+    if cfg!(target_os = "linux") {
+        let hostio_symbols = [
+            // vm_hooks module - core hostio functions
+            "account_balance",
+            "account_code",
+            "account_code_size",
+            "account_codehash",
+            "block_basefee",
+            "block_coinbase",
+            "block_gas_limit",
+            "block_number",
+            "block_timestamp",
+            "call_contract",
+            "chainid",
+            "contract_address",
+            "create1",
+            "create2",
+            "delegate_call_contract",
+            "emit_log",
+            "evm_gas_left",
+            "evm_ink_left",
+            "exit_early",
+            "math_add_mod",
+            "math_div",
+            "math_mod",
+            "math_mul_mod",
+            "math_pow",
+            "msg_reentrant",
+            "msg_sender",
+            "msg_value",
+            "native_keccak256",
+            "pay_for_memory_grow",
+            "read_args",
+            "read_return_data",
+            "return_data_size",
+            "static_call_contract",
+            "storage_cache_bytes32",
+            "storage_flush_cache",
+            "storage_load_bytes32",
+            "transient_load_bytes32",
+            "transient_store_bytes32",
+            "tx_gas_price",
+            "tx_ink_price",
+            "tx_origin",
+            "write_result",
+            // console module - debug logging functions
+            "log_f32",
+            "log_f64",
+            "log_i32",
+            "log_i64",
+            "log_txt",
+        ];
+        for sym in &hostio_symbols {
+            println!("cargo:rustc-link-arg-bins=-Wl,--export-dynamic-symbol={sym}");
+        }
+    }
+}

--- a/cargo-stylus/src/commands/replay.rs
+++ b/cargo-stylus/src/commands/replay.rs
@@ -302,7 +302,7 @@ pub fn build_shared_library(
 ) -> eyre::Result<()> {
     let mut cargo = sys::new_command("cargo");
 
-    cargo.current_dir(path).arg("build");
+    cargo.current_dir(path).arg("rustc");
 
     if let Some(f) = features {
         cargo.arg("--features").arg(f.join(","));
@@ -315,8 +315,22 @@ pub fn build_shared_library(
         .arg("--lib")
         .arg("--locked")
         .arg("--target")
-        .arg(rustc_host::from_cli()?)
-        .output()?;
+        .arg(rustc_host::from_cli()?);
+
+    // On Linux x86_64, Rust omits frame pointers by default. The stylusdb
+    // calltrace plugin uses frame pointers (GetFP()) to uniquely identify
+    // stack frames and build the call tree. Without them, every function
+    // returns the same stale RBP value and the plugin's dedup logic silently
+    // discards inner calls like increment() and set_number().
+    // macOS doesn't need this because its ABI mandates frame pointers.
+    if cfg!(target_os = "linux") {
+        cargo
+            .arg("--")
+            .arg("-C")
+            .arg("force-frame-pointers=yes");
+    }
+
+    cargo.output()?;
     Ok(())
 }
 

--- a/cargo-stylus/src/commands/replay.rs
+++ b/cargo-stylus/src/commands/replay.rs
@@ -324,10 +324,7 @@ pub fn build_shared_library(
     // discards inner calls like increment() and set_number().
     // macOS doesn't need this because its ABI mandates frame pointers.
     if cfg!(target_os = "linux") {
-        cargo
-            .arg("--")
-            .arg("-C")
-            .arg("force-frame-pointers=yes");
+        cargo.arg("--").arg("-C").arg("force-frame-pointers=yes");
     }
 
     cargo.output()?;

--- a/cargo-stylus/src/commands/usertrace.rs
+++ b/cargo-stylus/src/commands/usertrace.rs
@@ -104,11 +104,7 @@ async fn exec_inner(args: Args) -> eyre::Result<()> {
         .manifest_path
         .parent()
         .ok_or_else(|| eyre!("Failed to get contract directory"))?;
-    build_shared_library(
-        project_path.as_std_path(),
-        args.package.clone(),
-        features,
-    )?;
+    build_shared_library(project_path.as_std_path(), args.package.clone(), features)?;
 
     let target_dir = Workspace::current()?.metadata.target_directory;
     let library_extension = if macos { ".dylib" } else { ".so" };

--- a/cargo-stylus/src/commands/usertrace.rs
+++ b/cargo-stylus/src/commands/usertrace.rs
@@ -12,14 +12,14 @@ use std::{
 };
 
 use alloy::providers::Provider;
-use eyre::bail;
+use eyre::{bail, eyre};
 use stylus_tools::{
     core::{build::BuildConfig, project::workspace::Workspace, tracing::Trace},
     utils::{color::Color, sys},
 };
 
 use crate::{
-    commands::replay::find_shared_library,
+    commands::replay::{build_shared_library, find_shared_library},
     common_args::{ProjectArgs, ProviderArgs, TraceArgs},
     error::CargoStylusResult,
     utils::hostio,
@@ -90,12 +90,25 @@ async fn exec_inner(args: Args) -> eyre::Result<()> {
     }
     let contract = contracts.pop().unwrap();
 
-    // Build the shared library
+    // Build the WASM artifact
+    let features = args.features.clone();
     let config = BuildConfig {
         features: args.features.unwrap_or_default(),
         ..Default::default()
     };
     let _wasm = contract.build(&config)?;
+
+    // Build the native shared library (.so / .dylib) for replay
+    let project_path = contract
+        .package
+        .manifest_path
+        .parent()
+        .ok_or_else(|| eyre!("Failed to get contract directory"))?;
+    build_shared_library(
+        project_path.as_std_path(),
+        args.package.clone(),
+        features,
+    )?;
 
     let target_dir = Workspace::current()?.metadata.target_directory;
     let library_extension = if macos { ".dylib" } else { ".so" };
@@ -135,11 +148,11 @@ async fn exec_inner(args: Args) -> eyre::Result<()> {
                 "rust-stylusdb",
                 &[
                     "-o",
+                    &calltrace_cmd,
+                    "-o",
                     "b user_entrypoint",
                     "-o",
                     "r",
-                    "-o",
-                    &calltrace_cmd,
                     "-o",
                     "c",
                     "-o",


### PR DESCRIPTION
## Description

This PR adds support for debugging with StylusDB on Linux.

This work is implemented by the [Walnut](https://walnut.dev/) team. 

About Walnut:
Team focused on building debugging and simulation technology for blockchains. Collaborating with Starkware, Optimism, Arbitrum, Miden. Walnut's work on StylusDB, a debugger for Arbitrum Stylus, was merged into stylus-sdk-rs in the following PRs: https://github.com/OffchainLabs/stylus-sdk-rs/pull/370 and https://github.com/OffchainLabs/stylus-sdk-rs/pull/382

## Checklist

- [x] I have documented these changes where necessary.
- [x] I have read the [DCO][DCO] and ensured that these changes comply.
- [x] I assign this work under its [open source licensing][terms].

