### PR TITLE
Remove std from the dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,6 +1086,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "bobcat-host"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7b32369900e875c1d4ea62b66f1c222a0014bf12bde883e3c9efc1e6b13956"
+dependencies = [
+ "const-hex",
+ "keccak-const",
+]
+
+[[package]]
+name = "bobcat-panic"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8091c16396fc1505a2b564ac382814bfec36b9b0864ba595868a7a29302bfd24"
+dependencies = [
+ "bobcat-host",
+ "const-hex",
+ "paste",
+]
+
+[[package]]
 name = "bollard"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1258,7 +1279,10 @@ dependencies = [
  "alloy",
  "alloy-primitives",
  "alloy-sol-types",
+ "bobcat-panic",
+ "const-hex",
  "eyre",
+ "ruint",
  "stylus-sdk",
  "stylus-tools",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ clap = { version = "4.5.4", features = [ "derive", "color" ] }
 derivative = { version = "2.2.0", features = ["use_core"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 keccak-const = "0.2.0"
-lazy_static = "1.5.0"
+lazy_static = { version = "1.5.0", features = ["spin_no_std"] }
 mini-alloc = "1.0.0"
 sha3 = "0.10.8"
 rclite = "=0.4.1"
@@ -68,7 +68,7 @@ paste = "1.0.15"
 proc-macro-error = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-regex = "1.10.6"
+regex = { version = "1.10.6", default-features = false }
 syn = { version = "2.0.77", features = ["full", "visit-mut"] }
 syn-solidity = { version = "1.0.1", features = ["visit", "visit-mut"] }
 

--- a/examples/callee/Cargo.toml
+++ b/examples/callee/Cargo.toml
@@ -5,9 +5,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-alloy-primitives = "1.0.1"
-alloy-sol-types = "1.0.1"
+alloy-primitives = { version = "1.0.1", default-features = false }
+alloy-sol-types = { version = "1.0.1", default-features = false }
+bobcat-panic = { version = "0.7.35", features = ["panic"] }
 stylus-sdk = { path = "../../stylus-sdk" }
+ruint = { version = "1.15.0", default-features = false }
+const-hex = { version = "1.17.0", default-features = false }
 
 [dev-dependencies]
 alloy = { version = "1.0", features = ["contract", "signer-local", "rpc-types", "sha3-keccak"] }

--- a/examples/callee/src/lib.rs
+++ b/examples/callee/src/lib.rs
@@ -1,9 +1,13 @@
 // Copyright 2025, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
 
+#![no_std]
+
 #![cfg_attr(not(any(test, feature = "export-abi")), no_main)]
 
 extern crate alloc;
+
+use alloc::{vec, vec::Vec};
 
 #[allow(unused_imports)]
 use stylus_sdk::{

--- a/examples/callee/src/main.rs
+++ b/examples/callee/src/main.rs
@@ -3,6 +3,8 @@
 
 #![cfg_attr(not(any(test, feature = "export-abi")), no_main)]
 
+#![no_std]
+
 #[cfg(not(any(test, feature = "export-abi")))]
 #[no_mangle]
 pub extern "C" fn main() {}

--- a/examples/fallback_receive/src/lib.rs
+++ b/examples/fallback_receive/src/lib.rs
@@ -54,7 +54,7 @@ impl PaymentTracker {
     /// Example: contract.send(1 ether) or contract.transfer(1 ether)
     #[receive]
     #[payable]
-    pub fn receive(&mut self) -> Result<(), Vec<u8>> {
+    pub fn receive(&mut self) -> Result<(), alloc::vec::Vec<u8>> {
         let sender = self.vm().msg_sender();
         let amount = self.vm().msg_value();
 

--- a/stylus-proc/src/macros/public/types.rs
+++ b/stylus-proc/src/macros/public/types.rs
@@ -369,7 +369,7 @@ impl PublicImpl {
                 }
 
                 #[inline(always)]
-                fn receive(storage: &mut S) -> Option<Result<(), Vec<u8>>> {
+                fn receive(storage: &mut S) -> Option<Result<(), alloc::vec::Vec<u8>>> {
                     #receive
                 }
 
@@ -572,7 +572,7 @@ impl<E: FnExtension> PublicFn<E> {
                     Ok(args) => args,
                     Err(err) => {
                         internal::failed_to_decode_arguments(err);
-                        return Some(Err(Vec::new()));
+                        return Some(Err(alloc::vec::Vec::new()));
                     }
                 };
                 let result = Self::#name(#storage_arg #(#expand_args, )* );
@@ -641,7 +641,7 @@ impl<E: FnExtension> PublicFn<E> {
                     if let Err(err) = Self::#name(#storage_arg) {
                         Err(err)
                     } else {
-                        Ok(Vec::new())
+                        Ok(alloc::vec::Vec::new())
                     }
                 });
             }
@@ -681,7 +681,7 @@ impl<E: FnExtension> PublicFn<E> {
                 Ok(args) => args,
                 Err(err) => {
                     internal::failed_to_decode_arguments(err);
-                    return Some(Err(Vec::new()));
+                    return Some(Err(alloc::vec::Vec::new()));
                 }
             };
             let result = Self::#name(#storage_arg #(#expand_args, )* );

--- a/stylus-proc/src/macros/storage.rs
+++ b/stylus-proc/src/macros/storage.rs
@@ -193,12 +193,12 @@ impl Storage {
         parse_quote! {
             #[cfg(not(feature = "contract-client-gen"))]
             impl #impl_generics stylus_sdk::stylus_core::host::ValueDenier for #name #ty_generics #where_clause {
-                fn deny_value(&self, method_name: &str) -> Result<(), Vec<u8>> {
+                fn deny_value(&self, method_name: &str) -> Result<(), alloc::vec::Vec<u8>> {
                     if self.vm().msg_value() == stylus_sdk::alloy_primitives::U256::ZERO {
                         return Ok(());
                     }
                     stylus_sdk::console!("method {method_name} not payable");
-                    Err(vec![])
+                    Err(alloc::vec![])
                 }
             }
         }
@@ -210,7 +210,7 @@ impl Storage {
         parse_quote! {
             #[cfg(not(feature = "contract-client-gen"))]
             impl #impl_generics stylus_sdk::stylus_core::host::ConstructorGuard for #name #ty_generics #where_clause {
-                fn check_constructor_slot(&self) -> Result<(), Vec<u8>> {
+                fn check_constructor_slot(&self) -> Result<(), alloc::vec::Vec<u8>> {
                     let mut slot = unsafe {
                         stylus_sdk::storage::StorageBool::new(
                             stylus_sdk::abi::internal::CONSTRUCTOR_EXECUTED_SLOT,

--- a/stylus-proc/tests/public.rs
+++ b/stylus-proc/tests/public.rs
@@ -32,7 +32,7 @@ impl Contract {
     }
 
     #[receive]
-    fn receive(&mut self) -> Result<(), Vec<u8>> {
+    fn receive(&mut self) -> Result<(), alloc::vec::Vec<u8>> {
         Ok(())
     }
 

--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -24,7 +24,7 @@ keccak = ">=0.1.6, <0.2"
 mini-alloc = { workspace = true, optional = true }
 stylus-proc.workspace = true
 stylus-core.workspace = true
-ruint = "=1.15.0"
+ruint = { version = "=1.15.0", default-features = false }
 branches = { version = "=0.4.4", default-features = false }
 rclite = "=0.4.1"
 

--- a/stylus-sdk/src/abi/mod.rs
+++ b/stylus-sdk/src/abi/mod.rs
@@ -61,7 +61,7 @@ where
     /// Receive functions are always payable, take in no inputs, and return no outputs.
     /// If defined, they will always be called when a transaction does not send any
     /// calldata, regardless of the transaction having a value attached.
-    fn receive(storage: &mut S) -> Option<Result<(), Vec<u8>>>;
+    fn receive(storage: &mut S) -> Option<Result<(), alloc::vec::Vec<u8>>>;
 
     /// Called when no receive function is defined or when the transaction has calldata but it
     /// doesn't match any function selector.


### PR DESCRIPTION
## Description

Explicitly use `alloc::vec::Vec` and `alloc::vec` for the proc macros, disable default features for `lazy_static` and `regex`, and change the `callee` example to not use std by default. The standard library adds a lot of extra generated code and prevents teams building with Stylus from using custom panic handlers, making it harder to get stack traces during development and extra features. WIP until the repetitive use of `alloc::` is removed.

## Checklist

- [X] I have documented these changes where necessary.
- [X] I have read the [DCO][DCO] and ensured that these changes comply.
- [X] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
