### PR TITLE
Bump versions and changelog for 0.10.4-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 These crates follow [semver](https://semver.org).
 
+## [0.10.4](https://github.com/OffchainLabs/stylus-sdk-rs/releases/tag/v0.10.4) - 2026-04-09
+
+### Fixed
+
+- Fix `cargo stylus new` panic when installed from crates.io registry [#421](https://github.com/OffchainLabs/stylus-sdk-rs/pull/421)
+
 ## [0.10.3](https://github.com/OffchainLabs/stylus-sdk-rs/releases/tag/v0.10.3) - 2026-04-01
 
 ### New

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-stylus"
-version = "0.10.3"
+version = "0.10.4-rc.1"
 dependencies = [
  "alloy",
  "anstyle",
@@ -5252,7 +5252,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-core"
-version = "0.10.3"
+version = "0.10.4-rc.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-proc"
-version = "0.10.3"
+version = "0.10.4-rc.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5458,7 +5458,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-sdk"
-version = "0.10.3"
+version = "0.10.4-rc.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5520,7 +5520,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-test"
-version = "0.10.3"
+version = "0.10.4-rc.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "stylus-tools"
-version = "0.10.3"
+version = "0.10.4-rc.1"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.10.3"
+version = "0.10.4-rc.1"
 edition = "2021"
 authors = ["Offchain Labs"]
 license = "MIT OR Apache-2.0"
@@ -88,7 +88,7 @@ tokio = "1.45"
 
 # members
 stylus-sdk = { path = "stylus-sdk" }
-stylus-core = { path = "stylus-core", version = "0.10.2" }
-stylus-test = { path = "stylus-test", version = "0.10.2" }
-stylus-proc = { path = "stylus-proc", version = "0.10.2" }
-stylus-tools = { path = "stylus-tools", version = "0.10.2" }
+stylus-core = { path = "stylus-core", version = "0.10.4-rc.1" }
+stylus-test = { path = "stylus-test", version = "0.10.4-rc.1" }
+stylus-proc = { path = "stylus-proc", version = "0.10.4-rc.1" }
+stylus-tools = { path = "stylus-tools", version = "0.10.4-rc.1" }


### PR DESCRIPTION
## Summary
- Bump workspace version to `0.10.4-rc.1`
- Update inter-crate version references from `0.10.2` to `0.10.4-rc.1`
- Add changelog entry for 0.10.4 with the `cargo stylus new` registry fix (#421)