### PR TITLE
docs: deprecate `reentrant` feature flag and rewrite reentrancy docs

### DIFF
--- a/stylus-core/Cargo.toml
+++ b/stylus-core/Cargo.toml
@@ -25,4 +25,5 @@ alloy-primitives = { workspace = true, features = ["native-keccak"] }
 
 [features]
 default = []
+# Deprecated: see stylus-sdk Cargo.toml for details.
 reentrant = []

--- a/stylus-proc/Cargo.toml
+++ b/stylus-proc/Cargo.toml
@@ -38,6 +38,7 @@ assert_cmd = "2.0"
 [features]
 default = ["trybuild-tests"]
 export-abi = ["stylus-sdk/export-abi"]
+# Deprecated: see stylus-sdk Cargo.toml for details.
 reentrant = []
 stylus-test = ["stylus-sdk/stylus-test"]
 trybuild-tests = []

--- a/stylus-proc/src/lib.rs
+++ b/stylus-proc/src/lib.rs
@@ -189,9 +189,8 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
 ///
 /// # Reentrant calls
 ///
-/// Contracts that opt into reentrancy via the `reentrant` feature flag require extra care.
-/// When enabled, cross-contract calls must [`flush`] or [`clear`] the [`StorageCache`] to safeguard
-/// state. This happens automatically via the type system.
+/// Cross-contract calls automatically [`flush`] or [`clear`] the [`StorageCache`] to safeguard
+/// state. This happens via the type system -- no special feature flags are required.
 ///
 /// ```
 /// # extern crate alloc;
@@ -258,9 +257,8 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Note that in the context of a [`#[public]`][public] call, the `&mut impl` argument will
-/// correctly distinguish the method as being `write` or `payable`. This means you can write library
-/// code that will work regardless of whether the `reentrant` feature flag is enabled.
+/// Note that in the context of a [`#[public]`][public] call, the `&mut impl` argument will correctly
+/// distinguish the method as being `write` or `payable`.
 ///
 /// [sol_interface]: macro@sol_interface
 /// [public]: macro@public
@@ -402,22 +400,36 @@ pub fn derive_solidity_error(input: TokenStream) -> TokenStream {
 ///
 /// # Reentrancy
 ///
-/// If a contract calls another that then calls the first, it is said to be reentrant. By default,
-/// all Stylus programs revert when this happens. However, you can opt out of this behavior by
-/// recompiling with the `reentrant` flag.
+/// If a contract calls another that then calls the first, it is said to be reentrant.
+/// Numerous exploits and hacks in Web3 are attributable to developers misusing or not fully
+/// understanding reentrant patterns. Always follow the checks-effects-interactions pattern.
 ///
-/// ```toml
-/// stylus_sdk = { version = "0.3.0", features = ["reentrant"] }
-/// ```
+/// ## Storage cache flushing
 ///
-/// This is dangerous, and should be done only after careful review -- ideally by 3rd-party
-/// auditors. Numerous exploits and hacks have in Web3 are attributable to developers misusing or
-/// not fully understanding reentrant patterns.
+/// The SDK's primary reentrancy safety mechanism is automatic storage cache management.
+/// The high-level call functions in `stylus_sdk::call` (`call`, `delegate_call`, and
+/// `static_call`) flush the storage cache before every external call, ensuring that
+/// pending writes are persisted to storage before control is handed to another contract:
 ///
-/// If enabled, the Stylus SDK will flush the storage cache in between reentrant calls, persisting
-/// values to state that might be used by inner calls. Note that preventing storage invalidation is
-/// only part of the battle in the fight against exploits. You can tell if a call is reentrant via
-/// [`msg::reentrant`][reentrant], and condition your business logic accordingly.
+/// - `call` and `delegate_call` flush and clear (persist dirty values, then drop the
+///   in-memory cache).
+/// - `static_call` flushes without clearing (since static calls cannot modify storage,
+///   the cache remains valid).
+///
+/// This happens unconditionally for all contracts. When using `RawCall` directly, the
+/// cache is **not** flushed automatically -- if you have pending storage writes that
+/// the callee might read, call `.flush_storage_cache()` to persist dirty values without
+/// dropping the cache, or `.clear_storage_cache()` to persist and drop the cache
+/// (matching what `call` and `delegate_call` do).
+///
+/// ## The `reentrant` feature flag (deprecated)
+///
+/// The `reentrant` feature flag is **deprecated** and will be removed in a future
+/// release. Previously, contracts without this flag would automatically revert on
+/// reentrant calls via a `msg_reentrant()` check at the entrypoint. This guard is
+/// redundant — reentrancy safety is already provided by the cache flushing described
+/// above — and it indiscriminately blocks all reentrant calls, preventing use cases
+/// that require them.
 ///
 /// # [`TopLevelStorage`]
 ///
@@ -429,7 +441,6 @@ pub fn derive_solidity_error(input: TokenStream) -> TokenStream {
 /// [`TopLevelStorage`]: https://docs.rs/stylus-sdk/latest/stylus_sdk/storage/trait.TopLevelStorage.html
 /// [`sol_interface`]: macro@sol_interface
 /// [entrypoint]: macro@entrypoint
-/// [reentrant]: https://docs.rs/stylus-sdk/latest/stylus_sdk/msg/fn.reentrant.html
 /// [public]: macro@public
 /// [check]: https://github.com/OffchainLabs/cargo-stylus#developing-with-stylus
 #[proc_macro_attribute]
@@ -558,11 +569,10 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # [`pure`][pure] [`view`][view], and `write`
 ///
-/// For non-payable methods the [`#[public]`][public] macro can figure state mutability out for you
-/// based on the types of the arguments. Functions with `&self` will be considered `view`, those
-/// with `&mut self` will be considered `write`, and those with neither will be considered `pure`.
-/// Please note that `pure` and `view` functions may change the state of other contracts by calling
-/// into them, or even this one if the `reentrant` feature is enabled.
+/// For non-payable methods the [`#[public]`][public] macro can figure state mutability out for you based
+/// on the types of the arguments. Functions with `&self` will be considered `view`, those with
+/// `&mut self` will be considered `write`, and those with neither will be considered `pure`. Please note that
+/// `pure` and `view` functions may change the state of other contracts by calling into them.
 ///
 /// Please refer to the [SDK Feature Overview][overview] for more information on defining methods.
 ///

--- a/stylus-proc/src/lib.rs
+++ b/stylus-proc/src/lib.rs
@@ -257,8 +257,8 @@ pub fn sol_storage(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Note that in the context of a [`#[public]`][public] call, the `&mut impl` argument will correctly
-/// distinguish the method as being `write` or `payable`.
+/// Note that in the context of a [`#[public]`][public] call, the `&mut impl` argument will
+/// correctly distinguish the method as being `write` or `payable`.
 ///
 /// [sol_interface]: macro@sol_interface
 /// [public]: macro@public
@@ -411,10 +411,10 @@ pub fn derive_solidity_error(input: TokenStream) -> TokenStream {
 /// `static_call`) flush the storage cache before every external call, ensuring that
 /// pending writes are persisted to storage before control is handed to another contract:
 ///
-/// - `call` and `delegate_call` flush and clear (persist dirty values, then drop the
-///   in-memory cache).
-/// - `static_call` flushes without clearing (since static calls cannot modify storage,
-///   the cache remains valid).
+/// - `call` and `delegate_call` flush and clear (persist dirty values, then drop the in-memory
+///   cache).
+/// - `static_call` flushes without clearing (since static calls cannot modify storage, the cache
+///   remains valid).
 ///
 /// This happens unconditionally for all contracts. When using `RawCall` directly, the
 /// cache is **not** flushed automatically -- if you have pending storage writes that
@@ -569,10 +569,11 @@ pub fn entrypoint(attr: TokenStream, input: TokenStream) -> TokenStream {
 ///
 /// # [`pure`][pure] [`view`][view], and `write`
 ///
-/// For non-payable methods the [`#[public]`][public] macro can figure state mutability out for you based
-/// on the types of the arguments. Functions with `&self` will be considered `view`, those with
-/// `&mut self` will be considered `write`, and those with neither will be considered `pure`. Please note that
-/// `pure` and `view` functions may change the state of other contracts by calling into them.
+/// For non-payable methods the [`#[public]`][public] macro can figure state mutability out for you
+/// based on the types of the arguments. Functions with `&self` will be considered `view`, those
+/// with `&mut self` will be considered `write`, and those with neither will be considered `pure`.
+/// Please note that `pure` and `view` functions may change the state of other contracts by calling
+/// into them.
 ///
 /// Please refer to the [SDK Feature Overview][overview] for more information on defining methods.
 ///

--- a/stylus-proc/src/macros/entrypoint.rs
+++ b/stylus-proc/src/macros/entrypoint.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-2024, Offchain Labs, Inc.
+// Copyright 2023-2026, Offchain Labs, Inc.
 // For licensing, see https://github.com/OffchainLabs/stylus-sdk-rs/blob/main/licenses/COPYRIGHT.md
 
 use proc_macro2::{Ident, Span, TokenStream};
@@ -12,6 +12,8 @@ use syn::{
 use crate::consts::STRUCT_ENTRYPOINT_FN;
 
 /// Implementation for the [`#[entrypoint]`][crate::entrypoint] macro.
+///
+/// Generates the contract entrypoint and storage cache flush logic.
 pub fn entrypoint(
     attr: proc_macro::TokenStream,
     input: proc_macro::TokenStream,
@@ -141,6 +143,7 @@ fn user_entrypoint_fn(user_fn: Ident) -> Option<syn::ItemFn> {
         if #[cfg(feature = "stylus-test")] {
             None
         } else {
+            #[allow(deprecated)]
             let deny_reentrant = deny_reentrant();
             Some(parse_quote! {
                 #[no_mangle]
@@ -171,8 +174,19 @@ fn user_entrypoint_fn(user_fn: Ident) -> Option<syn::ItemFn> {
     }
 }
 
-/// Revert on reentrancy unless explicitly enabled
+/// Revert on reentrancy unless explicitly enabled.
+///
+/// # Deprecated
+///
+/// This guard is redundant and will be removed in a future release.
+/// Reentrancy safety is provided by automatic cache flushing in the
+/// high-level call functions (`call`, `delegate_call`, `static_call`).
+/// This guard indiscriminately blocks all reentrant calls, preventing
+/// use cases that require them.
 #[cfg(not(feature = "stylus-test"))]
+#[deprecated(
+    note = "this guard is redundant — reentrancy safety is provided by automatic cache flushing — and it prevents use cases that require reentrant calls. Will be removed in a future release."
+)]
 fn deny_reentrant() -> Option<syn::ExprIf> {
     cfg_if::cfg_if! {
         if #[cfg(feature = "reentrant")] {

--- a/stylus-sdk/Cargo.toml
+++ b/stylus-sdk/Cargo.toml
@@ -56,4 +56,7 @@ docs = []
 hostio = []
 mini-alloc = ["dep:mini-alloc"]
 stylus-test = ["dep:stylus-test", "dep:rclite", "stylus-proc/stylus-test"]
+# Deprecated: this guard is redundant (cache flushing provides reentrancy safety)
+# and blocks use cases that require reentrant calls. Will be removed in a future
+# major release.
 reentrant = ["stylus-proc/reentrant", "stylus-core/reentrant", "stylus-test/reentrant"]

--- a/stylus-test/Cargo.toml
+++ b/stylus-test/Cargo.toml
@@ -24,4 +24,5 @@ alloy-primitives = { workspace = true, features = ["native-keccak"] }
 
 [features]
 default = []
+# Deprecated: see stylus-sdk Cargo.toml for details.
 reentrant = []


### PR DESCRIPTION
Deprecate the `reentrant` feature flag and `deny_reentrant` entrypoint guard. The guard is redundant — reentrancy safety is provided by automatic storage cache flushing in the high-level call functions, which happens unconditionally — and it indiscriminately blocks all reentrant calls, preventing use cases that require them.

- Mark `deny_reentrant()` as #[deprecated]
- Add deprecation comments to `reentrant` feature in all crate Cargo.tomls
- Rewrite #[entrypoint] reentrancy docs to center cache flushing as the primary safety mechanism
- Stop recommending `msg_reentrant()` for business logic
- Remove `reentrant` feature references from sol_interface! and #[public] docs
- Fix broken doc link and typo

## Checklist

- [ ] I have documented these changes where necessary.
- [ ] I have read the [DCO][DCO] and ensured that these changes comply.
- [ ] I assign this work under its [open source licensing][terms].

[DCO]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/DCO.txt
[terms]: https://github.com/OffchainLabs/stylus-sdk-rs/blob/stylus/licenses/COPYRIGHT.md
