### PR TITLE
ci: drop archived actions-rs/cargo and align checkout on v6

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Install nightly with rustfmt
@@ -18,15 +18,11 @@ jobs:
           toolchain: nightly
           components: rustfmt
       - name: cargo +nightly fmt --check
-        uses: actions-rs/cargo@v1
-        with:
-          toolchain: nightly
-          command: fmt
-          args: --check
+        run: cargo +nightly fmt --check
   yamlfmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v5
       - name: install yamlfmt
         run: |
@@ -42,7 +38,7 @@ jobs:
       matrix:
         toolchain: [1.91.0, nightly-2025-10-01]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Install ${{ matrix.toolchain }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install stable
         uses: dtolnay/rust-toolchain@1.91.0
       - name: Get latest cargo-stylus version
@@ -70,7 +70,7 @@ jobs:
           - "verify_signature"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -114,7 +114,7 @@ jobs:
         toolchain: [1.91.0, nightly-2025-10-01]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -16,7 +16,7 @@ jobs:
         toolchain: [1.91.0, nightly-2025-10-01]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -16,7 +16,7 @@ jobs:
         toolchain: [1.91.0, nightly-2025-10-01]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install stable
         uses: dtolnay/rust-toolchain@1.91.0
       - name: Get latest cargo-stylus version
@@ -38,7 +38,7 @@ jobs:
         toolchain: [1.91.0, nightly-2025-10-01]
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Problem

Two small CI inconsistencies, both already solved elsewhere in this repo:

**1. `actions-rs/cargo@v1` in the `fmt` job** (`.github/workflows/check.yml:21`). The `actions-rs` org has been archived since 2022 and runs on the removed Node 12 runtime, so this step emits a deprecation annotation on every PR. It is also the odd one out: the `clippy` job in the very same file already invokes cargo through a plain `run:` step (`./ci/clippy.sh ...`), and the toolchain is already installed by `dtolnay/rust-toolchain` right above.

**2. `actions/checkout@v3` in 10 places** across `check.yml`, `integration.yml`, `linux.yml`, `mac.yml`, `smoke-test.yml` — while `sbom-export.yaml:14` already uses `actions/checkout@v6`.

## Fix

- replace the `actions-rs/cargo@v1` step with `run: cargo +nightly fmt --check`. This is behaviour-preserving: `actions-rs/cargo` with `toolchain: nightly`, `command: fmt`, `args: --check` executed exactly that, and it matches the step's own existing name (`cargo +nightly fmt --check`)
- bump the remaining `actions/checkout@v3` → `@v6`, so all 11 checkout steps in the repo agree on the version this repo already adopted

11 lines changed across 5 files; 4 lines net removed. Every checkout step in `.github/workflows` is now `@v6`.

## Notes

I aligned on `v6` rather than the newest `v7` deliberately — `v6` is what this repo already uses, so this is a consistency change rather than an upgrade decision. Happy to move to `v7` if you would prefer that.

## Verification

- all 6 workflow files re-parsed as YAML after the edit; every step in the edited files was read back through the parser to confirm the `fmt` job now carries `run: cargo +nightly fmt --check` and that the surrounding `dtolnay/rust-toolchain@stable` (`toolchain: nightly`, `components: rustfmt`) step is untouched
- `grep` confirms no `actions-rs` or `checkout@v3` references remain
- indentation and the existing 2-space YAML style are preserved, so the repo's own `yamlfmt -lint .github` job should stay green

CI-only change: no library code is touched.